### PR TITLE
Add Build Script and Revamp Test Script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# The path where you have installed LLVM/CLANG.
+# This is where make install put the executables.
+
+export LLVM_BUILD_DIR=/home/jimmy/clang34
+
+# The path where you are building systemc-clang
+export SYSTEMC_CLANG_BUILD_DIR=/home/jimmy/Documents/SE499/systemc-clang-build
+LLVMCOMPONENT=cppbackend
+RTTIFLAG=-fno-rtti 
+LLVMCONFIG=$LLVM_BUILD_DIR/bin/llvm-config
+
+export LLVM_CXX_FLAGS=`$LLVMCONFIG --cxxflags`
+export LLVM_CXX_FLAGS="$LLVM_CXX_FLAGS -fvisibility-inlines-hidden"
+export LLVM_LIBS=`$LLVMCONFIG --libs`
+export LLVM_LD_FLAGS=`$LLVMCONFIG --ldflags`
+export LLVM_LD_FLAGS=`echo $LLVM_LD_FLAGS | sed 's/ *$//g'`
+
+OLD_DIR=`pwd`
+
+cd $SYSTEMC_CLANG_BUILD_DIR
+if [ "$1" == "full-rebuild" ]; then
+    cmake ../systemc-clang
+    make clean
+fi
+make
+cd $OLD_DIR

--- a/tests/runTest.sh
+++ b/tests/runTest.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# Replace with your path for systemc
+SYSTEMC_HOME=/usr/local/systemc231
+
+# Replace with your path to `include` for clang
+CLANG_INCLUDE=/home/jimmy/clang34/lib/clang/3.4/include
+
 if [ "$#" -ne 1 ]; then
     echo "usage: runTest <filename.cpp>"
     exit
@@ -7,5 +14,5 @@ fi
 if [ -z $SYSTEMC_HOME ]; then 
     echo -e "environment variable \$SYSTEMC_HOME not defined, set the variable to SystemC directory\n(e.g. export SYSTEMC_HOME=\"/usr/local/systemc-2.3.1\")";
 else
-    systemc-clang $1 -- -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -I/usr/include/c++/4.2.1 -I/usr/include -I/$SYSTEMC_HOME/include;
+    systemc-clang $1 -- -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -I/usr/include -I/$SYSTEMC_HOME/include -I$CLANG_INCLUDE -x c++ -w -c;
 fi;

--- a/tests/runTest.sh
+++ b/tests/runTest.sh
@@ -6,6 +6,9 @@ SYSTEMC_HOME=/usr/local/systemc231
 # Replace with your path to `include` for clang
 CLANG_INCLUDE=/home/jimmy/clang34/lib/clang/3.4/include
 
+# Replace with your path to the systemc-clang executable
+SYSTEMC_CLANG=/home/jimmy/Documents/SE499/systemc-clang-build/systemc-clang
+
 if [ "$#" -ne 1 ]; then
     echo "usage: runTest <filename.cpp>"
     exit
@@ -14,5 +17,5 @@ fi
 if [ -z $SYSTEMC_HOME ]; then 
     echo -e "environment variable \$SYSTEMC_HOME not defined, set the variable to SystemC directory\n(e.g. export SYSTEMC_HOME=\"/usr/local/systemc-2.3.1\")";
 else
-    systemc-clang $1 -- -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -I/usr/include -I/$SYSTEMC_HOME/include -I$CLANG_INCLUDE -x c++ -w -c;
+    $SYSTEMC_CLANG $1 -- -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -I/usr/include -I/$SYSTEMC_HOME/include -I$CLANG_INCLUDE -x c++ -w -c;
 fi;


### PR DESCRIPTION
**Build**: modify the build.sh script with the correct environmental variables, and then go to systemc-clang folder and run `./build.sh`. The script should navigate to the build dir, build the executable, and come back.

**Test**: modify the runTest.sh script with the correct environmental variables, and just run it.