### PR TITLE
Fix for #40.

### DIFF
--- a/src/FindTemplateTypes.cpp
+++ b/src/FindTemplateTypes.cpp
@@ -95,6 +95,12 @@ bool FindTemplateTypes::VisitType(Type *type) {
   // TODO: Hack.  We need to figure out a clean way to identify types.
   else if (auto tt = type->getAs<TemplateSpecializationType>() ) {
     auto arg{ tt->getArgs() };
+    auto arg_kind{arg->getKind()};
+    // We have to make sure that it is fully evaluated before moving forward.
+    // If it is not then just keep parsing.
+    if (arg_kind == TemplateArgument::ArgKind::Expression) {
+      return true;
+    }
     template_types_.push_back(TemplateType(arg->getAsType().getAsString(), type));
   }
   else {

--- a/tests/data/templated-module.cpp
+++ b/tests/data/templated-module.cpp
@@ -11,7 +11,10 @@ struct my_data {
 SC_MODULE( non_template ) {
   int x;
   int y[10];
+
   sc_in<bool> blah;
+	sc_in< sc_bv<8> > filter_input, filter_second_input;
+
   my_data mdt;
   sc_signal<int> array_signal[10];
 

--- a/tests/t5-template-matching.cpp
+++ b/tests/t5-template-matching.cpp
@@ -93,7 +93,7 @@ TEST_CASE("Only parse a single top-level module", "[parsing]") {
     REQUIRE(found_module != module_decl.end());
 
     auto found_decl{found_module->second};
-    REQUIRE(found_decl->getIPorts().size() == 1);
+    REQUIRE(found_decl->getIPorts().size() == 3);
     REQUIRE(found_decl->getOPorts().size() == 0);
     REQUIRE(found_decl->getOtherVars().size() == 2);
   }

--- a/tests/template-method.cpp
+++ b/tests/template-method.cpp
@@ -4,8 +4,10 @@
 template<typename FP, int DIM>
 SC_MODULE( test ){
     sc_in<int> in;
+
     sc_out<int> out;
     sc_signal<int> test_signal;
+
     void entry_function_1() {
       std::cout << "value: " << DIM << std::endl;
     }


### PR DESCRIPTION
The issue was that when there are nested templates such as
sc_in<sc_bv<8>>, we need to ensure that with the class template
specialization, we need to check for the type of ArgKind to see if the
nested type is an expression.  If it is, continue parsing.