### PR TITLE
Continued fix for #40.

### DIFF
--- a/src/FindTemplateTypes.cpp
+++ b/src/FindTemplateTypes.cpp
@@ -66,16 +66,16 @@ FindTemplateTypes::type_vector_t FindTemplateTypes::Enumerate(
     return template_types_;
   }
 
-  //type->dump();
+  // type->dump();
   TraverseType(QualType(type, 0));
   return template_types_;
 }
 
 bool FindTemplateTypes::VisitType(Type *type) {
   QualType q{type->getCanonicalTypeInternal()};
-  //cout << "\n###### Type: " << q.getAsString() << " \n";
+  // cout << "\n###### Type: " << q.getAsString() << " \n";
   if (type->isBuiltinType()) {
-    //cout << " ==> builtin type: " << q.getAsString() << "\n";
+    // cout << " ==> builtin type: " << q.getAsString() << "\n";
     template_types_.push_back(TemplateType(q.getAsString(), type));
     return false;
   }
@@ -88,29 +88,42 @@ bool FindTemplateTypes::VisitType(Type *type) {
       auto tunder{tn.getUnderlying()};
       auto name{tunder.getAsTemplateDecl()->getNameAsString()};
       template_types_.push_back(TemplateType(name, type));
-      //cout << " ==> dependent type: " << name << "\n";
+      // cout << " ==> dependent type: " << name << "\n";
     }
-  } 
+  }
   // Identify the _Bool in the sc_in_clk
   // TODO: Hack.  We need to figure out a clean way to identify types.
-  else if (auto tt = type->getAs<TemplateSpecializationType>() ) {
-    auto arg{ tt->getArgs() };
+  else if (auto tt = type->getAs<TemplateSpecializationType>()) {
+    auto arg{tt->getArgs()};
     auto arg_kind{arg->getKind()};
     // We have to make sure that it is fully evaluated before moving forward.
     // If it is not then just keep parsing.
+    //
+    // Problem: For some reason for the nested type, the sugared version
+    // crashes when even trying to do a dump.  This seems to be an issue with
+    // clang itself.
+    //
+    // TODO: This should be consolidated with newer versions.
     if (arg_kind == TemplateArgument::ArgKind::Expression) {
+      // llvm::outs() << "#### HMM " << arg_kind << "\n";
+      // llvm::outs() << "\n#### HMM 2\n";
+      QualType q{tt->desugar()};
+      // const Type* ttt {tt->desugar().getTypePtr()};
+      //  ttt->dump();
+
+      template_types_.push_back(TemplateType(q.getAsString(), type));
       return true;
     }
-    template_types_.push_back(TemplateType(arg->getAsType().getAsString(), type));
-  }
-  else {
+    template_types_.push_back(
+        TemplateType(arg->getAsType().getAsString(), type));
+  } else {
     CXXRecordDecl *p_cxx_record{type->getAsCXXRecordDecl()};
     if (p_cxx_record != nullptr) {
       IdentifierInfo *info{p_cxx_record->getIdentifier()};
       // cout << "##### info; " << info->getNameStart() << "\n";
       if (info != nullptr) {
         template_types_.push_back(TemplateType(info->getNameStart(), type));
-        //cout << " ==> CXXRecord type: " << info->getNameStart() << "\n";
+        // cout << " ==> CXXRecord type: " << info->getNameStart() << "\n";
       }
     }
   }


### PR DESCRIPTION
There seems to be some problem with the way clang provides access to the
sugared type when it is a TemplateSpecializationType.

So, for the special case, I've simply accessed the desugared version.