### PR TITLE
Hotfix/33 other vars

### DIFF
--- a/scripts/sa-run.sh
+++ b/scripts/sa-run.sh
@@ -21,4 +21,4 @@ if [ -z "$SYSTEMC" ]; then
 fi
 
 # cp $SYSTEMC_CLANG_BUILD_DIR/systemc-clang $LLVM_INSTALL_DIR/bin/systemc-clang
-$LLVM_INSTALL_DIR/bin/systemc-clang $1 -- -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -I$LLVM_INSTALL_DIR/lib/clang/9.0.0/include/ -I/usr/include -I$SYSTEMC/include -x c++ -w -c 
+$SYSTEMC_CLANG_BUILD_DIR/systemc-clang $1 -- -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -I$LLVM_INSTALL_DIR/lib/clang/9.0.0/include/ -I/usr/include -I$SYSTEMC/include -x c++ -w -c 

--- a/src/FindTemplateTypes.cpp
+++ b/src/FindTemplateTypes.cpp
@@ -67,7 +67,7 @@ FindTemplateTypes::type_vector_t FindTemplateTypes::Enumerate(
 
 bool FindTemplateTypes::VisitTemplateSpecializationType(
     TemplateSpecializationType *special_type) {
-  //llvm::outs() << "=VisitTemplateSpecializationType=\n";
+  // llvm::outs() << "=VisitTemplateSpecializationType=\n";
   // special_type->dump();
   auto template_name{special_type->getTemplateName()};
   // template_name.dump();
@@ -91,11 +91,12 @@ bool FindTemplateTypes::VisitTemplateSpecializationType(
 }
 
 bool FindTemplateTypes::VisitCXXRecordDecl(CXXRecordDecl *cxx_record) {
-  //llvm::outs() << "=VisitCXXRecordDecl=\n";
+  // llvm::outs() << "=VisitCXXRecordDecl=\n";
   if (cxx_record != nullptr) {
     IdentifierInfo *info{cxx_record->getIdentifier()};
     if (info != nullptr) {
-      //llvm::outs() << " ==> CXXRecord type: " << info->getNameStart() << "\n";
+      // llvm::outs() << " ==> CXXRecord type: " << info->getNameStart() <<
+      // "\n";
       template_types_.push_back(
           TemplateType(info->getNameStart(), cxx_record->getTypeForDecl()));
     }
@@ -112,8 +113,12 @@ bool FindTemplateTypes::VisitBuiltinType(BuiltinType *bi_type) {
   LangOpts.CPlusPlus = true;
   clang::PrintingPolicy Policy(LangOpts);
 
-  auto type_name{ bi_type->getNameAsCString(Policy)};
+  auto type_name{bi_type->getNameAsCString(Policy)};
+  llvm::outs() << "type is : " << type_name << "\n";
+
   current_type_node_ = template_args_.addNode(TemplateType(type_name, bi_type));
+  template_types_.push_back(TemplateType(type_name, bi_type));
+
   if (template_args_.size() == 1) {
     template_args_.setRoot(current_type_node_);
   }
@@ -122,7 +127,7 @@ bool FindTemplateTypes::VisitBuiltinType(BuiltinType *bi_type) {
 }
 
 bool FindTemplateTypes::VisitTypedefType(TypedefType *typedef_type) {
-  //llvm::outs() << "=VisitTypedefType=\n";
+  // llvm::outs() << "=VisitTypedefType=\n";
   // typedef_type->dump();
   // child nodes of TemplateSpecializationType are not being invoked.
   if (auto special_type = typedef_type->getAs<TemplateSpecializationType>()) {
@@ -132,12 +137,13 @@ bool FindTemplateTypes::VisitTypedefType(TypedefType *typedef_type) {
 }
 
 bool FindTemplateTypes::VisitRecordType(RecordType *rt) {
-  //llvm::outs() << "=VisitRecordType=\n";
+  // llvm::outs() << "=VisitRecordType=\n";
   auto type_decl{rt->getDecl()};
   auto type_name{type_decl->getName()};
   // llvm::outs() << " ==> name : " << type_name << "\n";
 
   current_type_node_ = template_args_.addNode(TemplateType(type_name, rt));
+
   if (template_args_.size() == 1) {
     template_args_.setRoot(current_type_node_);
   }
@@ -215,12 +221,12 @@ bool FindTemplateTypes::VisitRecordType(RecordType *rt) {
   current_type_node_ = stack_current_node_.top();
   stack_current_node_.pop();
 
-  //llvm::outs() << "=END VisitRecordType=\n";
+  // llvm::outs() << "=END VisitRecordType=\n";
   return true;
 }
 
 bool FindTemplateTypes::VisitIntegerLiteral(IntegerLiteral *l) {
-  //llvm::outs() << "\n=VisitIntegerLiteral: \n";
+  // llvm::outs() << "\n=VisitIntegerLiteral: \n";
   //<< l->getValue().toString(10,true) <<
   //"\n"; _os << "== type ptr: " << l->getType().getTypePtr() << "\n"; _os <<
   //"== type name: " << l->getType().getAsString() << "\n";
@@ -253,11 +259,11 @@ void FindTemplateTypes::printTemplateArguments(llvm::raw_ostream &os) {
   }
   os << "\n";
 
-  //auto root_node{template_args_.getRoot()};
+  // auto root_node{template_args_.getRoot()};
   // template_args_.dump();
-  //os << "\n DFT: \n";
+  // os << "\n DFT: \n";
   // os << ">>>> Print arguments using DFT: " << root_node->getData() << "\n";
-  //auto s = template_args_.dft(root_node);
+  // auto s = template_args_.dft(root_node);
 }
 
 vector<std::string> FindTemplateTypes::getTemplateArguments() {

--- a/src/FindTemplateTypes.cpp
+++ b/src/FindTemplateTypes.cpp
@@ -58,8 +58,8 @@ FindTemplateTypes::type_vector_t FindTemplateTypes::Enumerate(
     return template_types_;
   }
 
-  // llvm::outs() << "####  Desugared #### \n";
-  // type->getUnqualifiedDesugaredType()->dump();
+  llvm::outs() << "####  Desugared #### \n";
+  type->getUnqualifiedDesugaredType()->dump();
 
   TraverseType(QualType(type->getUnqualifiedDesugaredType(), 1));
   return template_types_;
@@ -67,7 +67,7 @@ FindTemplateTypes::type_vector_t FindTemplateTypes::Enumerate(
 
 bool FindTemplateTypes::VisitTemplateSpecializationType(
     TemplateSpecializationType *special_type) {
-  llvm::outs() << "=VisitTemplateSpecializationType=\n";
+  //llvm::outs() << "=VisitTemplateSpecializationType=\n";
   // special_type->dump();
   auto template_name{special_type->getTemplateName()};
   // template_name.dump();
@@ -91,11 +91,11 @@ bool FindTemplateTypes::VisitTemplateSpecializationType(
 }
 
 bool FindTemplateTypes::VisitCXXRecordDecl(CXXRecordDecl *cxx_record) {
-  llvm::outs() << "=VisitCXXRecordDecl=\n";
+  //llvm::outs() << "=VisitCXXRecordDecl=\n";
   if (cxx_record != nullptr) {
     IdentifierInfo *info{cxx_record->getIdentifier()};
     if (info != nullptr) {
-      llvm::outs() << " ==> CXXRecord type: " << info->getNameStart() << "\n";
+      //llvm::outs() << " ==> CXXRecord type: " << info->getNameStart() << "\n";
       template_types_.push_back(
           TemplateType(info->getNameStart(), cxx_record->getTypeForDecl()));
     }
@@ -104,8 +104,25 @@ bool FindTemplateTypes::VisitCXXRecordDecl(CXXRecordDecl *cxx_record) {
   return true;
 }
 
+bool FindTemplateTypes::VisitBuiltinType(BuiltinType *bi_type) {
+  llvm::outs() << "=VisitBuiltinType=\n";
+  bi_type->dump();
+
+  clang::LangOptions LangOpts;
+  LangOpts.CPlusPlus = true;
+  clang::PrintingPolicy Policy(LangOpts);
+
+  auto type_name{ bi_type->getNameAsCString(Policy)};
+  current_type_node_ = template_args_.addNode(TemplateType(type_name, bi_type));
+  if (template_args_.size() == 1) {
+    template_args_.setRoot(current_type_node_);
+  }
+
+  return false;
+}
+
 bool FindTemplateTypes::VisitTypedefType(TypedefType *typedef_type) {
-  llvm::outs() << "=VisitTypedefType=\n";
+  //llvm::outs() << "=VisitTypedefType=\n";
   // typedef_type->dump();
   // child nodes of TemplateSpecializationType are not being invoked.
   if (auto special_type = typedef_type->getAs<TemplateSpecializationType>()) {
@@ -115,7 +132,7 @@ bool FindTemplateTypes::VisitTypedefType(TypedefType *typedef_type) {
 }
 
 bool FindTemplateTypes::VisitRecordType(RecordType *rt) {
-  llvm::outs() << "=VisitRecordType=\n";
+  //llvm::outs() << "=VisitRecordType=\n";
   auto type_decl{rt->getDecl()};
   auto type_name{type_decl->getName()};
   // llvm::outs() << " ==> name : " << type_name << "\n";
@@ -198,12 +215,12 @@ bool FindTemplateTypes::VisitRecordType(RecordType *rt) {
   current_type_node_ = stack_current_node_.top();
   stack_current_node_.pop();
 
-  llvm::outs() << "=END VisitRecordType=\n";
+  //llvm::outs() << "=END VisitRecordType=\n";
   return true;
 }
 
 bool FindTemplateTypes::VisitIntegerLiteral(IntegerLiteral *l) {
-  llvm::outs() << "\n=VisitIntegerLiteral: \n";
+  //llvm::outs() << "\n=VisitIntegerLiteral: \n";
   //<< l->getValue().toString(10,true) <<
   //"\n"; _os << "== type ptr: " << l->getType().getTypePtr() << "\n"; _os <<
   //"== type name: " << l->getType().getAsString() << "\n";
@@ -236,11 +253,11 @@ void FindTemplateTypes::printTemplateArguments(llvm::raw_ostream &os) {
   }
   os << "\n";
 
-  auto root_node{template_args_.getRoot()};
+  //auto root_node{template_args_.getRoot()};
   // template_args_.dump();
-  os << "\n DFT: \n";
+  //os << "\n DFT: \n";
   // os << ">>>> Print arguments using DFT: " << root_node->getData() << "\n";
-  auto s = template_args_.dft(root_node);
+  //auto s = template_args_.dft(root_node);
 }
 
 vector<std::string> FindTemplateTypes::getTemplateArguments() {

--- a/src/FindTemplateTypes.h
+++ b/src/FindTemplateTypes.h
@@ -64,6 +64,7 @@ class FindTemplateTypes : public RecursiveASTVisitor<FindTemplateTypes> {
   bool VisitTypedefType(TypedefType *typedef_type);
   bool VisitCXXRecordDecl(CXXRecordDecl *cxx_type);
   bool VisitRecordType(RecordType *rt);
+  bool VisitBuiltinType(BuiltinType *bi_type);
 
   ~FindTemplateTypes();
   type_vector_t Enumerate(const Type *type);

--- a/src/Matchers.h
+++ b/src/Matchers.h
@@ -172,7 +172,6 @@ class InstanceMatcher : public MatchFinder::MatchCallback {
 
   // This is the callback function whenever there is a match.
   virtual void run(const MatchFinder::MatchResult &result) {
-
     if (auto instance = const_cast<FieldDecl *>(
             result.Nodes.getNodeAs<FieldDecl>("instances_in_fielddecl"))) {
       std::string name{instance->getIdentifier()->getNameStart()};
@@ -209,7 +208,6 @@ class InstanceMatcher : public MatchFinder::MatchCallback {
       }
     }
   }
-
 
   void dump() {
     // Instances holds both FieldDecl and VarDecl as its base class Decl.
@@ -294,10 +292,13 @@ class PortMatcher : public MatchFinder::MatchCallback {
   //   - It must have a type that is either an array whose type is a c++ class derived 
   //     from a class name called "name"
   //   - Or, it is has a type that is a c++ class that is derived from class name "name".
+  auto makeArrayType(const std::string &name) {
+    return hasType(arrayType(hasElementType(hasDeclaration(cxxRecordDecl(isDerivedFrom(hasName(name)))))));
+  }
+
   auto makeSignalMatcher(const std::string &name) {
     return fieldDecl(anyOf(
-        hasType(arrayType(hasElementType(
-            hasDeclaration(cxxRecordDecl(isDerivedFrom(hasName(name))))))),
+          makeArrayType(name),
         hasType(cxxRecordDecl(isDerivedFrom(hasName(name))))));
   }
 
@@ -347,19 +348,18 @@ class PortMatcher : public MatchFinder::MatchCallback {
   template <typename T>
   void insert_port(PortType &port, T *decl, bool isFieldDecl = true) {
     // port is a map entry [CXXRecordDecl* => vector<PortDecl*>]
-    
+
     std::string name{};
     if (auto *fd = dyn_cast<FieldDecl>(decl)) {
       name = fd->getIdentifier()->getNameStart();
-    port.push_back(std::make_tuple(
-        name, new PortDecl(name, decl, parseTemplateType(fd))));
+      port.push_back(std::make_tuple(
+          name, new PortDecl(name, decl, parseTemplateType(fd))));
     } else {
       auto *vd = dyn_cast<VarDecl>(decl);
       name = vd->getIdentifier()->getNameStart();
-    port.push_back(std::make_tuple(
-        name, new PortDecl(name, decl, parseTemplateType(vd))));
+      port.push_back(std::make_tuple(
+          name, new PortDecl(name, decl, parseTemplateType(vd))));
     }
-
   }
 
   void registerMatchers(MatchFinder &finder) {
@@ -417,23 +417,49 @@ class PortMatcher : public MatchFinder::MatchCallback {
     // I wonder if the way to fix this is to to unless(match_all_ports))
     auto match_non_sc_types = cxxRecordDecl(
         match_module_decls,
-        forEach(fieldDecl(
+        forEach(
+          fieldDecl(
             anyOf(hasType(builtinType()),
-                  hasType(arrayType()),
-                  hasType(cxxRecordDecl(allOf(
-                      unless(hasName("sc_in")), unless(hasName("sc_inout")),
-                      unless(hasName("sc_out")), unless(hasName("sc_signal")),
+                  // hasType(arrayType(hasElementType(hasDeclaration(
+                          // unless(cxxRecordDecl(isDerivedFrom(hasName("sc_signal_inout_if")))))
+                        // )
+                      // )
+                    // ),
+                   hasType(cxxRecordDecl(allOf(
+                      unless(hasName("sc_in")), 
+                      unless(hasName("sc_inout")),
+                      unless(hasName("sc_out")), 
+                      unless(hasName("sc_signal_inout_if")),
+                      unless(hasName("sc_signal")),
                       unless(hasName("sc_stream_in")),
                       unless(hasName("sc_stream_out")))))))
             .bind("other_fields")));
 
+
+    // auto match_non_sc_types = cxxRecordDecl(
+        // match_module_decls,
+        // forEach(fieldDecl(
+            // anyOf(hasType(builtinType()),
+                  // hasType(arrayType()),
+                  // hasType(cxxRecordDecl(allOf(
+                        // unless(match_all_ports),
+                      // unless(hasName("sc_in")),
+                      // unless(hasName("sc_inout")),
+                      // unless(hasName("sc_out")),
+                      // unless(hasName("sc_signal")),
+                      // unless(hasName("sc_stream_in")),
+                      // unless(hasName("sc_stream_out")))))))
+            // .bind("other_fields")));
+//
     auto match_non_sc_types_vdecl = cxxRecordDecl(forEach(
         varDecl(
             anyOf(hasType(builtinType()),
-                  hasType(arrayType()),
                   hasType(cxxRecordDecl(allOf(
-                      unless(hasName("sc_in")), unless(hasName("sc_inout")),
-                      unless(hasName("sc_out")), unless(hasName("sc_signal")),
+                      unless(hasName("sc_in")), 
+                      unless(hasName("sc_inout")),
+                      unless(hasName("sc_out")), 
+                      unless(hasName("sc_signal")),
+                      unless(hasName("sc_signal_inout_if")),
                       unless(hasName("sc_stream_in")),
                       unless(hasName("sc_stream_out")))))))
             .bind("other_fields")));
@@ -446,12 +472,13 @@ class PortMatcher : public MatchFinder::MatchCallback {
     finder.addMatcher(match_non_sc_types_vdecl, this);
     finder.addMatcher(match_sc_ports, this);
 
-    // This is only for testing. 
+    // This is only for testing.
     //
-    // It is a way to show that we can write our own complex predicates for AST matchers :)
+    // It is a way to show that we can write our own complex predicates for AST
+    // matchers :)
     auto test_matcher =
         cxxRecordDecl(forEachDescendant(fieldDecl(matchesTypeName())));
-    //finder.addMatcher(test_matcher, this);
+    // finder.addMatcher(test_matcher, this);
   }
 
   virtual void run(const MatchFinder::MatchResult &result) {
@@ -485,29 +512,28 @@ class PortMatcher : public MatchFinder::MatchCallback {
       insert_port(signal_fields_, fd);
     }
 
-    if (auto fd = checkMatch<FieldDecl>("other_fields", result)) {
-      auto field_name{fd->getIdentifier()->getNameStart()};
-      llvm::outs() << " Found other_fields: " << field_name << "\n";
-//      insert_port(other_fields_, fd);
-    }
-
+    // if (auto fd = checkMatch<FieldDecl>("other_fields", result)) {
+    // auto field_name{fd->getIdentifier()->getNameStart()};
+    // llvm::outs() << " Found other_fields: " << field_name << "\n";
+    //     insert_port(other_fields_, fd);
+    // }
+    //
     if (auto fd = checkMatch<Decl>("other_fields", result)) {
       // These will be either FieldDecl or VarDecl.
-      
+
       if (auto *p_field{dyn_cast<FieldDecl>(fd)}) {
         auto field_name{p_field->getIdentifier()->getNameStart()};
         llvm::outs() << " Found field other_fields: " << field_name << "\n";
         insert_port(other_fields_, p_field);
 
       } else {
-        auto *p_var{dyn_cast<VarDecl>(fd)}; 
+        auto *p_var{dyn_cast<VarDecl>(fd)};
         auto field_name{p_var->getIdentifier()->getNameStart()};
         llvm::outs() << " Found var other_fields: " << field_name << "\n";
-      insert_port(other_fields_, p_var);
-
+        insert_port(other_fields_, p_var);
       }
-      //llvm::outs() << " Found field/vardecl other_fields: " << field_name << "\n";
-      //insert_port(other_fields_, fd);
+      // llvm::outs() << " Found field/vardecl other_fields: " << field_name <<
+      // "\n"; insert_port(other_fields_, fd);
     }
 
     if (auto fd = checkMatch<FieldDecl>("sc_stream_in", result)) {
@@ -642,12 +668,13 @@ class ModuleDeclarationMatcher : public MatchFinder::MatchCallback {
                    << decl->getIdentifier()->getNameStart()
                    << " CXXRecordDecl*: " << decl << "\n";
       std::string name{decl->getIdentifier()->getNameStart()};
-      //decl->dump();
+      // decl->dump();
       //
       // TODO: Should we need this separation now?
       // It seems that we can simply store them whether they are template
       // specializations or not.
-      // This is necessary because of the way clang represents them in their AST.
+      // This is necessary because of the way clang represents them in their
+      // AST.
       //
       if (isa<ClassTemplateSpecializationDecl>(decl)) {
         // llvm::outs() << "TEMPLATE SPECIAL\n";
@@ -702,7 +729,7 @@ class ModuleDeclarationMatcher : public MatchFinder::MatchCallback {
     if (remove_it != modules_.end()) {
       modules_.erase(remove_it);
     }
- }
+  }
 
   void pruneMatches() {
     // Must have found instances.

--- a/src/ModuleDecl.cpp
+++ b/src/ModuleDecl.cpp
@@ -525,9 +525,10 @@ void ModuleDecl::dumpPorts(raw_ostream &os, int tabn) {
   othervars_j["number_of_other_vars"] = other_fields_.size();
   for (auto mit : other_fields_) {
     auto name = get<0>(mit);
+    llvm::outs() << "\n######## OTHER FIRLDS " << name << "\n";;
     auto pd = get<1>(mit);
     auto template_type = pd->getTemplateType();
-    auto template_args{template_type->getTemplateArgumentsType()};
+    auto template_args{template_type->getTemplateArgTreePtr()};
     othervars_j[name] = pd->dump_json(os);
   }
 

--- a/src/PortDecl.cpp
+++ b/src/PortDecl.cpp
@@ -55,7 +55,6 @@ json PortDecl::dump_json(raw_ostream &os) {
   port_j["port_name"] = getName();
 
   auto args{template_type_->getTemplateArgTreePtr()};
-  llvm::outs() << "### Memory leak: " << args->size() << "\n";
   args->dump();
 
   for (auto const &node : *args) {
@@ -64,7 +63,7 @@ json PortDecl::dump_json(raw_ostream &os) {
     auto parent_node{node->getParent()};
     auto parent_data{parent_node->getDataPtr()};
     if (parent_node->getDataPtr() == node->getDataPtr()) {
-      llvm::outs() << "Insert parent node: " << type_data->getTypeName()
+      llvm::outs() << "\nInsert parent node: " << type_data->getTypeName()
                    << "\n";
       port_j["port_arguments"][type_data->getTypeName()] = nullptr;
     } else {

--- a/src/PortDecl.cpp
+++ b/src/PortDecl.cpp
@@ -18,11 +18,11 @@ PortDecl::PortDecl()
 PortDecl::PortDecl(const string &name, FindTemplateTypes *tt)
     : port_name_{name}, template_type_{tt} {}
 
-PortDecl::PortDecl(const string &name, const FieldDecl *fd,
+PortDecl::PortDecl(const string &name, const Decl *fd,
                    FindTemplateTypes *tt)
     : port_name_{name},
       template_type_{tt},
-      field_decl_{const_cast<FieldDecl *>(fd)} {}
+      field_decl_{const_cast<Decl*>(fd)} {}
 
 PortDecl::PortDecl(const PortDecl &from) {
   port_name_ = from.port_name_;
@@ -34,8 +34,13 @@ void PortDecl::setModuleName(const string &name) { port_name_ = name; }
 
 string PortDecl::getName() const { return port_name_; }
 
-FieldDecl *PortDecl::getFieldDecl() const { return field_decl_; }
+FieldDecl *PortDecl::getFieldDecl() const { 
+  return dyn_cast<FieldDecl>(field_decl_);
+}
 
+VarDecl *PortDecl::getAsVarDecl() const { 
+  return dyn_cast<VarDecl>(field_decl_);
+}
 FindTemplateTypes *PortDecl::getTemplateType() { return template_type_; }
 
 void PortDecl::dump(llvm::raw_ostream &os, int tabn) {

--- a/src/PortDecl.h
+++ b/src/PortDecl.h
@@ -19,7 +19,7 @@ class PortDecl {
 public:
   PortDecl();
   PortDecl(const string &, FindTemplateTypes *);
-  PortDecl(const string &, const FieldDecl*, FindTemplateTypes *);
+  PortDecl(const string &, const Decl*, FindTemplateTypes *);
 
   PortDecl(const PortDecl &);
 
@@ -30,6 +30,7 @@ public:
   /// Get parameters
   string getName() const;
   FieldDecl* getFieldDecl() const;
+  VarDecl *getAsVarDecl() const;
   FindTemplateTypes *getTemplateType();
 
   // Print
@@ -42,7 +43,7 @@ private:
   string port_name_;
   // This holds the types for the port
   FindTemplateTypes *template_type_;
-  FieldDecl *field_decl_;
+  Decl*field_decl_;
 };
 } // namespace scpar
 #endif

--- a/tests/member-variable-sc-buffer.cpp
+++ b/tests/member-variable-sc-buffer.cpp
@@ -3,26 +3,34 @@
 SC_MODULE(FIR) {
   sc_in_clk clk;
   sc_in<double> sample;       
+  static const int ORDER = 5;
+  static const double single;
+  static const double c[ORDER+1];
+  int x;
+  /*
   sc_out<double> result;
   sc_int<32> myint;
   sc_signal<int> mysignal;
+  */
   SC_CTOR(FIR) {      
     SC_METHOD(behavior);
     sensitive << clk.neg();
   }
   private:
-  static const int ORDER = 5;
-  static const double c[ORDER+1];
+
   sc_buffer<double> i[ORDER];
+
   void behavior() {
     double sum = c[0] * sample.read();
     for (int j=1; j<=ORDER; ++j)
       sum = sum + c[j] * i[j-1].read();
-    result.write(sum);
+    //result.write(sum);
 
     i[0].write(sample.read());
     for (int j=1; j<ORDER; ++j)
       i[j].write(i[j-1].read());
+
+    x = sum;
   }
 };
 

--- a/tests/sreg-test.cpp
+++ b/tests/sreg-test.cpp
@@ -111,7 +111,7 @@ TEST_CASE("sreg example", "[llnl-examples]") {
     REQUIRE(sreg_fwd_decl->getOPorts().size() == 0);
     REQUIRE(sreg_fwd_decl->getIOPorts().size() == 0);
     REQUIRE(sreg_fwd_decl->getSignals().size() == 1);
-    REQUIRE(sreg_fwd_decl->getOtherVars().size() == 0);
+    REQUIRE(sreg_fwd_decl->getOtherVars().size() == 1);
     REQUIRE(sreg_fwd_decl->getInputStreamPorts().size() == 1);
     REQUIRE(sreg_fwd_decl->getOutputStreamPorts().size() == 1);
 
@@ -126,7 +126,7 @@ TEST_CASE("sreg example", "[llnl-examples]") {
     REQUIRE(sreg_fwd_rev_decl->getOPorts().size() == 0);
     REQUIRE(sreg_fwd_rev_decl->getIOPorts().size() == 0);
     REQUIRE(sreg_fwd_rev_decl->getSignals().size() == 7);
-    REQUIRE(sreg_fwd_rev_decl->getOtherVars().size() == 0);
+    REQUIRE(sreg_fwd_rev_decl->getOtherVars().size() == 3);
     REQUIRE(sreg_fwd_rev_decl->getInputStreamPorts().size() == 1);
     REQUIRE(sreg_fwd_rev_decl->getOutputStreamPorts().size() == 1);
   }

--- a/tests/t5-template-matching.cpp
+++ b/tests/t5-template-matching.cpp
@@ -164,7 +164,9 @@ TEST_CASE("Testing top-level module: test", "[top-module]") {
     REQUIRE(found_decl->getOPorts().size() == 1);
     // This is 4 because sc_buffer is also inheriting from the signal interface.
     REQUIRE(found_decl->getSignals().size() == 4);
-    REQUIRE(found_decl->getOtherVars().size() == 0);
+    // 1 non-array, and 2 array others
+    // TODO: Currently, only the 1 non-array is being recognized.
+    REQUIRE(found_decl->getOtherVars().size() == 1);
 
     // TODO: Check the template parameters.
     //
@@ -174,7 +176,9 @@ TEST_CASE("Testing top-level module: test", "[top-module]") {
     REQUIRE(found_decl2->getOPorts().size() == 1);
     // 1 regular signal, 2 array signals, 1 sc_buffer, which is a signal too.
     REQUIRE(found_decl2->getSignals().size() == 4);
-    REQUIRE(found_decl2->getOtherVars().size() == 0);
+    // 1 non-array, and 2 array others
+    // TODO: Currently, only the 1 non-array is being recognized.
+    REQUIRE(found_decl2->getOtherVars().size() == 1);
     
     // TODO: Check the template parameters.
     //


### PR DESCRIPTION
This is an incremental fix to #33.  Currently, this identifies non-array other fields.  Detecting array types may require AST matchers to simply detect them, and then filter them out in the call back function since getting it to do that with matchers seems to be quite cumbersome.