### PR TITLE
Remove the test that was provided to find all the VarDecl

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ set( UNIT_TEST_LIST
   t5-template-matching
   # subtree-matcher-test
   clock-parsing
-  find-var-decl
+  # find-var-decl
   hotfix-40-findtemplatetypes
   )
 


### PR DESCRIPTION
This is just removing a test that may have been used for illustrating how to find all the VarDecl.