### PR TITLE
Revert llnl-example to use the RVD flag.

### DIFF
--- a/examples/llnl-examples/sreg.h
+++ b/examples/llnl-examples/sreg.h
@@ -4,15 +4,15 @@
 
 #include "systemc.h"
 
-//#if defined(RVD)
+#if defined(RVD)
 #include "sc_rvd.h"
 template <typename T> using sc_stream_in = sc_rvd_in<T>;
 template <typename T> using sc_stream_out = sc_rvd_out<T>;
 
-// #else
-// #include "sc_stream_ports.h"
-// #endif
-//
+#else
+#include "sc_stream_ports.h"
+#endif
+
 // Port & Channel Prefix
 // m: port master
 // s: port slave


### PR DESCRIPTION
TODO: We need a better way to incorporate the compilation flag for
tests.