### PR TITLE
Bump clang 10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,8 @@ install:
   - | # Build clang 
     cd DEPENDS
     wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-    #wget https://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-    #tar xf clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz 
-    #mv clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04 clang-7.0.0
-    tar x clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-    mv clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz clang-10.0.0
+    tar xf clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+    mv clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04 clang-10.0.0
 
     # Debug
     # Setup flags

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,16 +61,19 @@ install:
   - cd ..
   - | # Build clang 
     cd DEPENDS
-    wget https://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-    tar xf clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz 
-    mv clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04 clang-7.0.0
+    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+    #wget https://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+    #tar xf clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz 
+    #mv clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04 clang-7.0.0
+    tar x clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+    mv clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz clang-10.0.0
 
     # Debug
     # Setup flags
-    export LLVM_INSTALL_DIR=`pwd`/clang-7.0.0
+    export LLVM_INSTALL_DIR=`pwd`/clang-10.0.0
     export LLVMCONFIG=$LLVM_INSTALL_DIR/bin/llvm-config
     export LLVM_LD_FLAGS=-L$LLVM_INSTALL_DIR/lib
-    export LLVM_CXX_FLAGS="-I/home/travis/build/rseac/systemc-clang/DEPENDS/clang-7.0.0/include  -fPIC -fvisibility-inlines-hidden -std=c++14 -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -ffunction-sections -fdata-sections -O3 -DNDEBUG  -fno-exceptions -fno-rtti -D_GNU_SOURCE -fvisibility-inlines-hidden -Wsign-compare"
+    export LLVM_CXX_FLAGS="-I/home/travis/build/rseac/systemc-clang/DEPENDS/clang-10.0.0/include  -fPIC -fvisibility-inlines-hidden -std=c++14 -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -ffunction-sections -fdata-sections -O3 -DNDEBUG  -fno-exceptions -fno-rtti -D_GNU_SOURCE -fvisibility-inlines-hidden -Wsign-compare"
     export LLVM_LIBS="-lLLVMLTO -lLLVMPasses -lLLVMObjCARCOpts -lLLVMSymbolize -lLLVMDebugInfoPDB -lLLVMDebugInfoDWARF -lLLVMMIRParser -lLLVMFuzzMutate -lLLVMCoverage -lLLVMTableGen -lLLVMDlltoolDriver -lLLVMOrcJIT -lLLVMXCoreDisassembler -lLLVMXCoreCodeGen -lLLVMXCoreDesc -lLLVMXCoreInfo -lLLVMXCoreAsmPrinter -lLLVMSystemZDisassembler -lLLVMSystemZCodeGen -lLLVMSystemZAsmParser -lLLVMSystemZDesc -lLLVMSystemZInfo -lLLVMSystemZAsmPrinter -lLLVMSparcDisassembler -lLLVMSparcCodeGen -lLLVMSparcAsmParser -lLLVMSparcDesc -lLLVMSparcInfo -lLLVMSparcAsmPrinter -lLLVMPowerPCDisassembler -lLLVMPowerPCCodeGen -lLLVMPowerPCAsmParser -lLLVMPowerPCDesc -lLLVMPowerPCInfo -lLLVMPowerPCAsmPrinter -lLLVMNVPTXCodeGen -lLLVMNVPTXDesc -lLLVMNVPTXInfo -lLLVMNVPTXAsmPrinter -lLLVMMSP430CodeGen -lLLVMMSP430Desc -lLLVMMSP430Info -lLLVMMSP430AsmPrinter -lLLVMMipsDisassembler -lLLVMMipsCodeGen -lLLVMMipsAsmParser -lLLVMMipsDesc -lLLVMMipsInfo -lLLVMMipsAsmPrinter -lLLVMLanaiDisassembler -lLLVMLanaiCodeGen -lLLVMLanaiAsmParser -lLLVMLanaiDesc -lLLVMLanaiAsmPrinter -lLLVMLanaiInfo -lLLVMHexagonDisassembler -lLLVMHexagonCodeGen -lLLVMHexagonAsmParser -lLLVMHexagonDesc -lLLVMHexagonInfo -lLLVMBPFDisassembler -lLLVMBPFCodeGen -lLLVMBPFAsmParser -lLLVMBPFDesc -lLLVMBPFInfo -lLLVMBPFAsmPrinter -lLLVMARMDisassembler -lLLVMARMCodeGen -lLLVMARMAsmParser -lLLVMARMDesc -lLLVMARMInfo -lLLVMARMAsmPrinter -lLLVMARMUtils -lLLVMAMDGPUDisassembler -lLLVMAMDGPUCodeGen -lLLVMAMDGPUAsmParser -lLLVMAMDGPUDesc -lLLVMAMDGPUInfo -lLLVMAMDGPUAsmPrinter -lLLVMAMDGPUUtils -lLLVMAArch64Disassembler -lLLVMAArch64CodeGen -lLLVMAArch64AsmParser -lLLVMAArch64Desc -lLLVMAArch64Info -lLLVMAArch64AsmPrinter -lLLVMAArch64Utils -lLLVMObjectYAML -lLLVMLibDriver -lLLVMOption -lLLVMWindowsManifest -lLLVMX86Disassembler -lLLVMX86AsmParser -lLLVMX86CodeGen -lLLVMGlobalISel -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMX86Desc -lLLVMMCDisassembler -lLLVMX86Info -lLLVMX86AsmPrinter -lLLVMX86Utils -lLLVMMCJIT -lLLVMLineEditor -lLLVMInterpreter -lLLVMExecutionEngine -lLLVMRuntimeDyld -lLLVMCodeGen -lLLVMTarget -lLLVMCoroutines -lLLVMipo -lLLVMInstrumentation -lLLVMVectorize -lLLVMScalarOpts -lLLVMLinker -lLLVMIRReader -lLLVMAsmParser -lLLVMInstCombine -lLLVMBitWriter -lLLVMAggressiveInstCombine -lLLVMTransformUtils -lLLVMAnalysis -lLLVMProfileData -lLLVMObject -lLLVMMCParser -lLLVMMC -lLLVMDebugInfoCodeView -lLLVMDebugInfoMSF -lLLVMBitReader -lLLVMCore -lLLVMBinaryFormat -lLLVMSupport -lLLVMDemangle"
     cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,10 +85,11 @@ before_script:
 script:
   - export SYSTEMC=$SYSTEMC_HOME/
   - export CC=$LLVM_INSTALL_DIR/bin/clang
+  - echo $CC
   - export CXX=$LLVM_INSTALL_DIR/bin/clang++
   - echo $CXX
   - mkdir -p TEMP; cd TEMP;
-  - cmake ../ -DCMAKE_VERBOSE_MAKEFILE=on -DENABLE_TESTS=on -DXLAT=on && make;
+  - cmake ../ -DCMAKE_VERBOSE_MAKEFILE=on -DENABLE_TESTS=ON -DXLAT=ON && make;
   - echo "Run tests"
   - ctest
     #- cmake ../ -DCMAKE_VERBOSE_MAKEFILE=on && make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,10 +74,9 @@ set( SYSTEMC_DIR $ENV{SYSTEMC} )
 set( EXTRA_INCLUDE_DIR $ENV{EXTRA_INCLUDE_DIR} )
 
 # Default plugin status 
-if ("${XLAT}" STREQUAL "")
-  set( PLUGIN_XLAT OFF )
-else()
-  set( PLUGIN_XLAT ${XLAT})
+set( PLUGIN_XLAT OFF )
+if ("${XLAT}" STREQUAL "ON")
+  set( PLUGIN_XLAT ON)
 endif()
 
 
@@ -338,9 +337,10 @@ set( TARGET "systemc-clang" )
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -iquote ${PROJECT_SOURCE_DIR}/src")
 include_directories(
   "${LLVM_INSTALL_DIR}/include"
-  plugins/xlat
   "${CATCH_INCLUDE_DIR}"
   )
+
+set( SRC_LIB libsystemc-clang )
 
 if(NOT "${EXTRA_INCLUDE_DIR}" STREQUAL "")
   include_directories( "${EXTRA_INCLUDE_DIR}")
@@ -350,14 +350,19 @@ endif()
 link_directories( ${LLVM_INSTALL_DIR}/lib )
 
 add_subdirectory(src)
-add_subdirectory(plugins)
+
+if(PLUGIN_XLAT) 
+  include_directories(plugins/xlat)
+  add_subdirectory(plugins)
+  set( SRC_LIB libsystemc-clang libxlat )
+endif()
+
 
 if( TESTS_ON )
   add_subdirectory(tests)
   enable_testing()
 endif()
 
-set( SRC_LIB libsystemc-clang libxlat )
 
 add_executable(
   ${TARGET}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It parses RTL constructs and some TLM 2.0 constructs.
 
 ## Requirements
 
-* [llvm/clang](https://releases.llvm.org/download.html) (version 7.0.0)
+* [llvm/clang](https://releases.llvm.org/download.html) (version 10.0.0)
 * [SystemC](http://systemc.org) version 2.3.3. Please see [SystemC Installation notes](https://github.com/anikau31/systemc-clang/blob/master/doc/systemc-install.mkd)
 * c++14 is required.  We are using some features that necessitate c++14.  Down-porting it is also possible, but not supported.
 

--- a/driver-tooling.cpp
+++ b/driver-tooling.cpp
@@ -1,10 +1,8 @@
 #include "SystemCClang.h"
 #include "PluginAction.h"
-using namespace scpar;
-using namespace std;
 
 
 int main(int argc, const char **argv) {
-  PluginAction<SystemCClang> systemc_clang(argc, argv);
+  scpar::PluginAction systemc_clang(argc, argv);
   return 0;
 }

--- a/driver-xlat.cpp
+++ b/driver-xlat.cpp
@@ -1,12 +1,9 @@
 #include "plugins/xlat/Xlat.h"
 #include "PluginAction.h"
-using namespace scpar;
-using namespace std;
 
 #include "plugins/xlat/Xlat.h"
 
 int main(int argc, const char **argv) {
-  cout << "Plugin XLAT\n";
-    PluginAction<Xlat> pa(argc, argv);
+  scpar::PluginAction pa(argc, argv);
   return 0;
 }

--- a/plugins/xlat/XlatEntryMethod.cpp
+++ b/plugins/xlat/XlatEntryMethod.cpp
@@ -79,7 +79,7 @@ bool XlatMethod::TraverseStmt(Stmt *stmt) {
     TRY_TO(TraverseUnaryOperator((UnaryOperator *) stmt));
   }
   else if (isa<MaterializeTemporaryExpr>(stmt)) {
-    TRY_TO(TraverseStmt(((MaterializeTemporaryExpr *) stmt)->GetTemporaryExpr()));
+    TRY_TO(TraverseStmt(((MaterializeTemporaryExpr *) stmt)->getSubExpr()));
   }
 
   else if (isa<IntegerLiteral>(stmt)) {

--- a/src/PluginAction.h
+++ b/src/PluginAction.h
@@ -18,13 +18,14 @@
 #include <clang/Tooling/Tooling.h>
 #include "SystemCClang.h"
 
-using namespace scpar;
 
+namespace scpar {
 // We need to find a way to pass the top-level module as an argument.
 //
 // Source:
 // https://github.com/facebook/facebook-clang-plugins/blob/master/libtooling/ast_exporter_bin.cpp
 //
+/*
 template <typename PluginConsumer>
 class SimpleFrontendActionFactory
     : public clang::tooling::FrontendActionFactory {
@@ -37,7 +38,8 @@ class SimpleFrontendActionFactory
   std::string top_;
 };
 
-template <typename A>
+*/
+//template <typename A>
 class PluginAction {
  public:
   PluginAction(int argc, const char **argv) {
@@ -52,10 +54,13 @@ class PluginAction {
     CommonOptionsParser OptionsParser(argc, argv, category);
     ClangTool Tool(OptionsParser.getCompilations(),
                    OptionsParser.getSourcePathList());
-    factory.reset(
-        new SimpleFrontendActionFactory<LightsCameraAction<A>>(topModule));
-    Tool.run(factory.get());
+    // factory.reset(
+        // new SimpleFrontendActionFactory<LightsCameraAction<A>>(topModule));
+    // Tool.run(factory.get());
+
+    runToolOnCode(make_unique<AXN>(topModule), argv[1] );
   };
+};
 };
 
 #endif /* _PLUGIN_ACTION_H_ */

--- a/src/PluginAction.h
+++ b/src/PluginAction.h
@@ -20,26 +20,6 @@
 
 
 namespace scpar {
-// We need to find a way to pass the top-level module as an argument.
-//
-// Source:
-// https://github.com/facebook/facebook-clang-plugins/blob/master/libtooling/ast_exporter_bin.cpp
-//
-/*
-template <typename PluginConsumer>
-class SimpleFrontendActionFactory
-    : public clang::tooling::FrontendActionFactory {
- public:
-  explicit SimpleFrontendActionFactory(std::string topModule)
-      : top_{topModule} {};
-  clang::FrontendAction *create() override { return new PluginConsumer(top_); }
-
- private:
-  std::string top_;
-};
-
-*/
-//template <typename A>
 class PluginAction {
  public:
   PluginAction(int argc, const char **argv) {
@@ -54,11 +34,7 @@ class PluginAction {
     CommonOptionsParser OptionsParser(argc, argv, category);
     ClangTool Tool(OptionsParser.getCompilations(),
                    OptionsParser.getSourcePathList());
-    // factory.reset(
-        // new SimpleFrontendActionFactory<LightsCameraAction<A>>(topModule));
-    // Tool.run(factory.get());
-
-    runToolOnCode(make_unique<AXN>(topModule), argv[1] );
+    runToolOnCode(make_unique<SystemCClangAXN>(topModule), argv[1] );
   };
 };
 };

--- a/src/SystemCClang.h
+++ b/src/SystemCClang.h
@@ -81,9 +81,9 @@ class SystemCConsumer : public ASTConsumer,
 
  private:
   std::string top_;
-  Model *systemcModel_;
-  ASTContext &context_;
-  SourceManager &sm_;
+  Model* systemcModel_;
+  ASTContext& context_;
+  SourceManager& sm_;
 };  // End class SystemCConsumer
 
 //
@@ -97,21 +97,33 @@ class SystemCClang : public SystemCConsumer {
       : SystemCConsumer(ci, top) {}
 };
 
-template <typename A>
-class LightsCameraAction : public clang::ASTFrontendAction {
+class AXN : public ASTFrontendAction {
  public:
-  LightsCameraAction(std::string topModule) : top_{topModule} {};
-
- private:
+  AXN(std::string topModule) : top_{topModule} {};
   std::string top_;
 
- protected:
-  virtual std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
-      CompilerInstance& ci, llvm::StringRef inFile) {
-    return std::unique_ptr<clang::ASTConsumer>(new A(ci, top_));
-  };
+ public:
+  virtual std::unique_ptr<ASTConsumer> CreateASTConsumer(
+      clang::CompilerInstance &Compiler, llvm::StringRef inFile) {
+    return std::unique_ptr<ASTConsumer>(new SystemCConsumer(Compiler, top_));
+  }
 };
 
+// template <typename A>
+// class LightsCameraAction : public clang::ASTFrontendAction {
+ // public:
+  // LightsCameraAction(std::string topModule) : top_{topModule} {};
+//
+ // private:
+  // std::string top_;
+//
+ // protected:
+  // std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
+      // CompilerInstance& ci, llvm::StringRef inFile) override {
+    // return std::unique_ptr<clang::ASTConsumer>(new A(ci, top_));
+  // };
+// };
+//
 }  // End namespace scpar
 
 #endif

--- a/src/SystemCClang.h
+++ b/src/SystemCClang.h
@@ -15,19 +15,15 @@
 #ifndef _SYSTEMC_CLANG_H_
 #define _SYSTEMC_CLANG_H_
 
-//#include "clang/AST/AST.h"
 #include "clang/AST/ASTConsumer.h"
-//#include "clang/AST/ASTImporter.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
-//#include "clang/Parse/Parser.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Tooling.h"
 
-using namespace clang::driver;
-using namespace clang::tooling;
+//using namespace clang::driver;
 
 // / This is the include files we add to parse SystemC
 #include "FindArgument.h"
@@ -46,12 +42,11 @@ using namespace clang::tooling;
 #include "FindTemplateParameters.h"
 #include "FindWait.h"
 #include "Model.h"
-#include "SCuitable/FindGPUMacro.h"
-#include "SCuitable/GlobalSuspensionAutomata.h"
-#include "SuspensionAutomata.h"
-//#include "Utility.h"
+//#include "SCuitable/FindGPUMacro.h"
+//#include "SCuitable/GlobalSuspensionAutomata.h"
+//#include "SuspensionAutomata.h"
 
-using namespace clang;
+using namespace clang::tooling;
 
 namespace scpar {
 
@@ -62,13 +57,13 @@ class SystemCConsumer : public ASTConsumer,
   llvm::raw_ostream& os_;
 
  public:
-  SystemCConsumer(CompilerInstance&, std::string top = "!none");
-  SystemCConsumer(ASTUnit* from_ast, std::string top = "!none");
+  SystemCConsumer(CompilerInstance &, std::string top = "!none");
+  SystemCConsumer(ASTUnit *from_ast, std::string top = "!none");
   virtual ~SystemCConsumer();
 
   Model* getSystemCModel();
   const std::string& getTopModule() const;
-  void setTopModule(const std::string& top_module_decl);
+  void setTopModule(const std::string &top_module_decl);
   ASTContext& getContext() const;
   SourceManager& getSourceManager() const;
 
@@ -77,13 +72,13 @@ class SystemCConsumer : public ASTConsumer,
   virtual bool preFire();
   virtual bool postFire();
 
-  virtual void HandleTranslationUnit(ASTContext& context);
+  virtual void HandleTranslationUnit(ASTContext &context);
 
  private:
   std::string top_;
-  Model* systemcModel_;
-  ASTContext& context_;
-  SourceManager& sm_;
+  Model *systemcModel_;
+  ASTContext &context_;
+  SourceManager &sm_;
 };  // End class SystemCConsumer
 
 //
@@ -93,13 +88,13 @@ class SystemCConsumer : public ASTConsumer,
 
 class SystemCClang : public SystemCConsumer {
  public:
-  SystemCClang(CompilerInstance& ci, std::string top)
+  SystemCClang(CompilerInstance &ci, const std::string &top)
       : SystemCConsumer(ci, top) {}
 };
 
-class AXN : public ASTFrontendAction {
+class SystemCClangAXN : public ASTFrontendAction {
  public:
-  AXN(std::string topModule) : top_{topModule} {};
+  SystemCClangAXN(const std::string &topModule) : top_{topModule} {};
   std::string top_;
 
  public:
@@ -109,21 +104,6 @@ class AXN : public ASTFrontendAction {
   }
 };
 
-// template <typename A>
-// class LightsCameraAction : public clang::ASTFrontendAction {
- // public:
-  // LightsCameraAction(std::string topModule) : top_{topModule} {};
-//
- // private:
-  // std::string top_;
-//
- // protected:
-  // std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
-      // CompilerInstance& ci, llvm::StringRef inFile) override {
-    // return std::unique_ptr<clang::ASTConsumer>(new A(ci, top_));
-  // };
-// };
-//
 }  // End namespace scpar
 
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ set( UNIT_TEST_LIST
   t1
   t2
   t3
-  sreg-test
+  #sreg-test
   t4-matchers
   t5-template-matching
   clock-parsing
@@ -52,6 +52,13 @@ set( UNIT_TEST_LIST
   tree-test
   )
 
+if (PLUGIN_XLAT)
+set ( UNIT_XLAT_TEST_LIST 
+  sreg-test
+  )
+endif()
+
+set (UNIT_TEST_LIST ${UNIT_TEST_LIST} ${UNIT_XLAT_TEST_LIST})
 include(CTest)
 
 # catch2 may have headers colliding with other local files, 
@@ -65,7 +72,12 @@ foreach(NAME IN LISTS UNIT_TEST_LIST)
   set(TARGET_NAME ${NAME})
   add_executable(${TARGET_NAME} main.cpp ${TEST_SOURCE_NAME} )
     
-  target_link_libraries(${TARGET_NAME} PUBLIC libsystemc-clang PUBLIC libxlat ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_SYSTEM_LIBS})
+  target_link_libraries(${TARGET_NAME} PUBLIC libsystemc-clang ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_SYSTEM_LIBS})
+  
+  if (PLUGIN_XLAT) 
+    target_link_libraries(${TARGET_NAME} PUBLIC libxlat)
+  endif()
+
   target_include_directories(${TARGET_NAME} PUBLIC ../externals/catch2/ PUBLIC ../tests/ PUBLIC ${CMAKE_BINARY_DIR}/tests/ )
   add_test( NAME ${TARGET_NAME} COMMAND ${TARGET_NAME} 
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/data/ )

--- a/tests/data/llnl-examples/sreg-driver.cpp
+++ b/tests/data/llnl-examples/sreg-driver.cpp
@@ -1,9 +1,14 @@
 /* Placeholder for further modules */
 // TODO: include example directory
-#include "sreg.h"
+#include "sc_rvd.h"
 //#include "sc_stream.h"
 
 //#include <systemc.h>
+
+template <typename T> using sc_stream = sc_rvd<T>;
+template <typename T> using sc_stream_in = sc_rvd_in<T>;
+template <typename T> using sc_stream_out = sc_rvd_out<T>;
+#include "sreg.h"
 
 SC_MODULE(test) {
 public:
@@ -21,7 +26,7 @@ public:
 int sc_main(int argc, char *argv[]) {
   sc_signal<bool> clk;
   sc_signal<bool> reset;
-  sc_rvd<int> in_s;
+  sc_stream<int> in_s;
   test test_instance("testing");
   test_instance.clk(clk);
   test_instance.m_port(in_s);

--- a/tests/data/llnl-examples/sreg-driver.cpp
+++ b/tests/data/llnl-examples/sreg-driver.cpp
@@ -1,5 +1,6 @@
 /* Placeholder for further modules */
 // TODO: include example directory
+#define RVD 1
 #include "sc_rvd.h"
 //#include "sc_stream.h"
 

--- a/tests/hotfix-40-findtemplatetypes.cpp
+++ b/tests/hotfix-40-findtemplatetypes.cpp
@@ -23,7 +23,6 @@ TEST_CASE("Basic parsing checks", "[parsing]") {
   std::string code = R"(
 #include "systemc.h"
 #include "sreg.h"
-//#include "sc_stream.h"
 
 template< int E, int F>
 struct fp_t {
@@ -185,7 +184,7 @@ int sc_main(int argc, char *argv[]) {
   INFO(systemc_clang::test_data_dir);
   auto catch_test_args = systemc_clang::catch_test_args;
   catch_test_args.push_back("-I" + systemc_clang::test_data_dir +
-                            "/llnl-examples/");
+                            "/llnl-examples/zfpsynth/shared");
 
   ASTUnit *from_ast =
       tooling::buildASTFromCodeWithArgs(code, catch_test_args).release();
@@ -213,6 +212,7 @@ int sc_main(int argc, char *argv[]) {
          << module_decl.size());
 
     // There are two modules: ram, test.
+    //REQUIRE(module_instance_map.size() == 2 );
     REQUIRE(module_decl.size() == 2);
     REQUIRE(ram_module != nullptr);
     REQUIRE(test_module != nullptr);

--- a/tests/sreg-test.cpp
+++ b/tests/sreg-test.cpp
@@ -21,8 +21,8 @@ TEST_CASE("sreg example", "[llnl-examples]") {
   ASTUnit *from_ast =
       tooling::buildASTFromCodeWithArgs(code, catch_test_args).release();
 
-  //  SystemCConsumer sc{from_ast};
-  Xlat sc{from_ast};
+    SystemCConsumer sc{from_ast};
+  //Xlat sc{from_ast};
   sc.HandleTranslationUnit(from_ast->getASTContext());
   auto model{sc.getSystemCModel()};
   // These are instances.
@@ -78,7 +78,7 @@ TEST_CASE("sreg example", "[llnl-examples]") {
     REQUIRE(sreg_fwd_decl->getOPorts().size() == 0);
     REQUIRE(sreg_fwd_decl->getIOPorts().size() == 0);
     REQUIRE(sreg_fwd_decl->getSignals().size() == 1);
-    REQUIRE(sreg_fwd_decl->getOtherVars().size() == 1);
+    REQUIRE(sreg_fwd_decl->getOtherVars().size() == 0);
     REQUIRE(sreg_fwd_decl->getInputStreamPorts().size() == 1);
     REQUIRE(sreg_fwd_decl->getOutputStreamPorts().size() == 1);
 
@@ -93,7 +93,8 @@ TEST_CASE("sreg example", "[llnl-examples]") {
     REQUIRE(sreg_fwd_rev_decl->getOPorts().size() == 0);
     REQUIRE(sreg_fwd_rev_decl->getIOPorts().size() == 0);
     REQUIRE(sreg_fwd_rev_decl->getSignals().size() == 7);
-    REQUIRE(sreg_fwd_rev_decl->getOtherVars().size() == 3);
+    // captures the static constexpr
+    REQUIRE(sreg_fwd_rev_decl->getOtherVars().size() == 2);
     REQUIRE(sreg_fwd_rev_decl->getInputStreamPorts().size() == 1);
     REQUIRE(sreg_fwd_rev_decl->getOutputStreamPorts().size() == 1);
   }

--- a/tests/sreg-test.cpp
+++ b/tests/sreg-test.cpp
@@ -16,7 +16,7 @@ TEST_CASE("sreg example", "[llnl-examples]") {
 
   auto catch_test_args = systemc_clang::catch_test_args;
   catch_test_args.push_back("-I" + systemc_clang::test_data_dir +
-                            "/llnl-examples/");
+                            "/llnl-examples/zfpsynth/shared");
 
   ASTUnit *from_ast =
       tooling::buildASTFromCodeWithArgs(code, catch_test_args).release();

--- a/tests/tree-test.cpp
+++ b/tests/tree-test.cpp
@@ -43,13 +43,15 @@ TEST_CASE("Tree representation of template types", "[Tree]") {
   auto five = t.addNode(Node{"5"});
   auto six = t.addNode(Node{"6"});
 
+  /*
   // Layout of the tree
   //       0
   //      / \
   //    1    2
-  //   /    / \ 
+  //   /    /  
   //  6 -- 3   5
   //
+  */
   t.addEdge(zero, one);
   t.addEdge(zero, two);
   t.addEdge(two, three);


### PR DESCRIPTION
Internal API changes to clang 10.0.0 requires changes to both the Xlat plugin and core sytemc-clang.  @mayagokhale: minor changes to XlatEntryMethod.cpp was done.  I will merge into master only after local versions of clang are bumped up.