### PR TITLE
Netlist generation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,10 @@ if (USE_SAUTO)
     )
 endif (USE_SAUTO)
 
+add_library(findtemplatetypes 
+  FindTemplateTypes.cpp
+  )
+
 add_library (libsystemc-clang
   ModuleDecl.cpp
   FindModule.cpp

--- a/src/FindMemberFieldMatcher.h
+++ b/src/FindMemberFieldMatcher.h
@@ -1,0 +1,52 @@
+#ifndef _FIND_MEMBER_FIELD_MATCHER_H_
+#define _FIND_MEMBER_FIELD_MATCHER_H_
+
+#include <vector>
+
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/ASTMatchers/ASTMatchersInternal.h"
+#include "clang/ASTMatchers/ASTMatchersMacros.h"
+
+using namespace clang::ast_matchers;
+using namespace clang;
+
+namespace clang {
+class Type;
+}
+
+namespace sc_ast_matchers {
+
+class FindMemberFieldMatcher : public MatchFinder::MatchCallback {
+ private:
+  std::vector<clang::FieldDecl *> found_fields_;
+
+ public:
+  const std::vector<clang::FieldDecl *> &getFieldDecls() {
+    return found_fields_;
+  }
+
+  void registerMatchers(MatchFinder &finder) {
+    auto member_fields_match =
+        recordDecl(forEach(fieldDecl().bind("field_decl")));
+
+    finder.addMatcher(member_fields_match, this);
+  }
+
+  virtual void run(const MatchFinder::MatchResult &result) {
+    auto fd = const_cast<FieldDecl *>(
+        result.Nodes.getNodeAs<FieldDecl>("field_decl"));
+
+    found_fields_.push_back(fd);
+  }
+
+  void dump() {
+    for (auto const &field : found_fields_) {
+      field->dump();
+    }
+  }
+};
+
+};  // namespace sc_ast_matchers
+
+#endif

--- a/src/FindTemplateParameters.cpp
+++ b/src/FindTemplateParameters.cpp
@@ -1,8 +1,6 @@
 #include "FindTemplateParameters.h"
 #include "FindTemplateTypes.h"
-#include "clang/AST/DeclTemplate.h"
-#include "clang/AST/Type.h"
-#include "clang/Basic/SourceManager.h"
+//#include "clang/AST/Type.h"
 
 using namespace scpar;
 
@@ -64,8 +62,8 @@ bool FindTemplateParameters::VisitCXXRecordDecl(CXXRecordDecl *declaration) {
   return false;
 }
 
-vector<string> FindTemplateParameters::getTemplateParameters() const {
-  vector<string> parm_list;
+const std::vector<std::string> FindTemplateParameters::getTemplateParameters() const {
+  std::vector<std::string> parm_list;
   if ((template_parameters_ == nullptr) ||
       (template_parameters_->size() <= 0)) {
     return parm_list;
@@ -78,8 +76,8 @@ vector<string> FindTemplateParameters::getTemplateParameters() const {
   return parm_list;
 }
 
-vector<string> FindTemplateParameters::getTemplateArgs() const {
-  vector<string> arg_list;
+const std::vector<std::string> FindTemplateParameters::getTemplateArgs() const {
+  std::vector<std::string> arg_list;
   if ((template_args_ == nullptr) || (template_args_->size() == 0)) {
     return arg_list;
   }
@@ -92,7 +90,7 @@ vector<string> FindTemplateParameters::getTemplateArgs() const {
         auto number{arg.getAsIntegral()};
         SmallString<10> small_str;
         number.toString(small_str);
-        arg_list.push_back(string(small_str.c_str()));
+        arg_list.push_back(std::string(small_str.c_str()));
         os_ << "Arg: " << small_str << "\n";
       }; break;
       case TemplateArgument::ArgKind::Type: {

--- a/src/FindTemplateParameters.h
+++ b/src/FindTemplateParameters.h
@@ -1,31 +1,36 @@
 #ifndef _FIND_TEMPLATE_PARAMETERS_H_
 #define _FIND_TEMPLATE_PARAMETERS_H_
 
-#include "clang/AST/DeclCXX.h"
+#include <vector>
+
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "llvm/Support/raw_ostream.h"
 
+// Forward declarations.
+namespace clang {
+class CXXRecordDecl;
+}
+
 namespace scpar {
 
-using namespace clang;
-using namespace std;
-
-class FindTemplateParameters : public RecursiveASTVisitor<FindTemplateParameters> {
-public:
-  FindTemplateParameters(CXXRecordDecl *, llvm::raw_ostream &);
-  virtual bool VisitCXXRecordDecl(CXXRecordDecl *decl);
+class FindTemplateParameters
+    : public clang::RecursiveASTVisitor<FindTemplateParameters> {
+ public:
+  FindTemplateParameters(clang::CXXRecordDecl *, llvm::raw_ostream &);
+  virtual bool VisitCXXRecordDecl(clang::CXXRecordDecl *decl);
 
   virtual ~FindTemplateParameters();
 
-  void dump();
-  vector<string> getTemplateParameters() const;
-  vector<string> getTemplateArgs() const;
+  const std::vector<std::string> getTemplateParameters() const;
+  const std::vector<std::string> getTemplateArgs() const;
 
-private:
-  CXXRecordDecl *declaration_;
+  void dump();
+
+ private:
+  clang::CXXRecordDecl *declaration_;
   llvm::raw_ostream &os_;
-  TemplateParameterList *template_parameters_;
-  const TemplateArgumentList *template_args_;
+  clang::TemplateParameterList *template_parameters_;
+  const clang::TemplateArgumentList *template_args_;
 };
-} // namespace scpar
+}  // namespace scpar
 #endif

--- a/src/FindTemplateTypes.cpp
+++ b/src/FindTemplateTypes.cpp
@@ -1,6 +1,7 @@
 #include "FindTemplateTypes.h"
-
+#include "FindMemberFieldMatcher.h"
 using namespace scpar;
+using namespace sc_ast_matchers;
 
 //////////////////////////////////////////////////////////////////////
 // TemplateType
@@ -23,6 +24,20 @@ std::string TemplateType::toString() const { return getTypeName(); }
 
 const Type *TemplateType::getTypePtr() const { return type_ptr_; }
 
+void TemplateType::dump() {
+  if (!type_ptr_) {
+    return;
+  }
+
+  if (type_ptr_->isClassType() || type_ptr_->isRecordType()) {
+    auto cxx_decl{type_ptr_->getAsCXXRecordDecl()};
+
+    FindMemberFieldMatcher field_matcher{};
+    MatchFinder registry{};
+    field_matcher.registerMatchers(registry);
+    //registry.match(*cxx_decl, getContext());
+  }
+}
 //////////////////////////////////////////////////////////////////////
 // FindTemplateTypes
 //////////////////////////////////////////////////////////////////////
@@ -156,7 +171,7 @@ bool FindTemplateTypes::VisitRecordType(RecordType *rt) {
     const TemplateArgumentList &arg_list{ctsd->getTemplateArgs()};
     for (unsigned int i{0}; i < arg_list.size(); ++i) {
       const TemplateArgument &targ{arg_list[i]};
-      //llvm::outs() << " ====> template argument: ";
+      // llvm::outs() << " ====> template argument: ";
       targ.dump();
       // llvm::outs() << "\n";
       // TODO Write this into the vector.
@@ -224,8 +239,8 @@ bool FindTemplateTypes::VisitIntegerLiteral(IntegerLiteral *l) {
   //"\n"; _os << "== type ptr: " << l->getType().getTypePtr() << "\n"; _os <<
   //"== type name: " << l->getType().getAsString() << "\n";
   // template_types_.push_back(TemplateType(l->getValue().toString(10, true),
-                                         // l->getType().getTypePtr()));
-//
+  // l->getType().getTypePtr()));
+  //
   return false;
 }
 
@@ -267,7 +282,7 @@ json FindTemplateTypes::dump_json() {
 void FindTemplateTypes::printTemplateArguments(llvm::raw_ostream &os) {
   auto root_node{template_args_.getRoot()};
   auto s{template_args_.dft(root_node)};
-  //os << "> Template args (DFT): " << s << "\n";
+  // os << "> Template args (DFT): " << s << "\n";
 }
 
 std::vector<std::string> FindTemplateTypes::getTemplateArguments() {
@@ -283,3 +298,5 @@ std::vector<std::string> FindTemplateTypes::getTemplateArguments() {
 }
 
 size_t FindTemplateTypes::size() { return template_types_.size(); }
+
+

--- a/src/FindTemplateTypes.cpp
+++ b/src/FindTemplateTypes.cpp
@@ -100,17 +100,19 @@ bool FindTemplateTypes::VisitCXXRecordDecl(CXXRecordDecl *cxx_record) {
 }
 
 bool FindTemplateTypes::VisitBuiltinType(BuiltinType *bi_type) {
-  llvm::outs() << "=VisitBuiltinType=\n";
+  llvm::outs() << "=VisitBuiltinType= \n";
   // bi_type->dump();
 
   clang::LangOptions LangOpts;
   LangOpts.CPlusPlus = true;
   clang::PrintingPolicy Policy(LangOpts);
 
-  auto type_name{bi_type->getNameAsCString(Policy)};
+  //auto type_name{bi_type->getNameAsCString(Policy)};
+  auto type_name{bi_type->getName(Policy)};
   llvm::outs() << "type is : " << type_name << "\n";
 
-  current_type_node_ = template_args_.addNode(TemplateType(type_name, bi_type));
+  TemplateType tt{type_name.str(), bi_type};
+  current_type_node_ = template_args_.addNode(tt);
   template_types_.push_back(TemplateType(type_name, bi_type));
 
   if (template_args_.size() == 1) {

--- a/src/FindTemplateTypes.cpp
+++ b/src/FindTemplateTypes.cpp
@@ -24,20 +24,6 @@ std::string TemplateType::toString() const { return getTypeName(); }
 
 const Type *TemplateType::getTypePtr() const { return type_ptr_; }
 
-void TemplateType::dump() {
-  if (!type_ptr_) {
-    return;
-  }
-
-  if (type_ptr_->isClassType() || type_ptr_->isRecordType()) {
-    auto cxx_decl{type_ptr_->getAsCXXRecordDecl()};
-
-    FindMemberFieldMatcher field_matcher{};
-    MatchFinder registry{};
-    field_matcher.registerMatchers(registry);
-    //registry.match(*cxx_decl, getContext());
-  }
-}
 //////////////////////////////////////////////////////////////////////
 // FindTemplateTypes
 //////////////////////////////////////////////////////////////////////

--- a/src/FindTemplateTypes.h
+++ b/src/FindTemplateTypes.h
@@ -7,10 +7,11 @@
 #include "json.hpp"
 
 #include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/AST/Type.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "Tree.h"
+
+namespace clang { class Type; }
 
 namespace scpar {
 using namespace clang;
@@ -27,17 +28,18 @@ class TemplateType {
   TemplateType();
 
   // Overloaded constructor
-  TemplateType(std::string, const Type *);
+  TemplateType(std::string, const clang::Type *);
   ~TemplateType();
   TemplateType(const TemplateType &);
 
   std::string getTypeName() const;
   std::string toString() const;
-  const Type *getTypePtr() const;
+  const clang::Type *getTypePtr() const;
+  void dump();
 
  private:
   std::string type_name_;
-  const Type *type_ptr_;
+  const clang::Type *type_ptr_;
 };
 
 // This class is going to find the arguments from templates
@@ -68,13 +70,14 @@ class FindTemplateTypes : public RecursiveASTVisitor<FindTemplateTypes> {
   bool VisitBuiltinType(BuiltinType *bi_type);
 
   ~FindTemplateTypes();
-  void Enumerate(const Type *type);
+  void Enumerate(const clang::Type *type);
   type_vector_t getTemplateArgumentsType();
+  std::vector<std::string> getTemplateArguments();
+  Tree<TemplateType> *getTemplateArgTreePtr();
+  size_t size();
+
   void printTemplateArguments(llvm::raw_ostream &os);
   json dump_json();
-  std::vector<std::string> getTemplateArguments();
-  size_t size();
-  Tree<TemplateType> *getTemplateArgTreePtr();
 
  private:
   // (std::string, Type*)

--- a/src/InstanceMatcher.h
+++ b/src/InstanceMatcher.h
@@ -8,9 +8,14 @@
 #include "clang/ASTMatchers/ASTMatchersInternal.h"
 #include "clang/ASTMatchers/ASTMatchersMacros.h"
 
+#include "ModuleInstanceType.h"
+
+
+using namespace clang;
 using namespace clang::ast_matchers;
 
 namespace sc_ast_matchers {
+
 
 AST_MATCHER(FieldDecl, hasTemplateDeclParent) {
   auto parent{Node.getParent()};
@@ -25,46 +30,6 @@ AST_MATCHER(FieldDecl, hasTemplateDeclParent) {
   }
 
   return true;
-};
-
-struct ModuleInstanceType {
-  std::string var_name;
-  std::string var_type_name;
-  std::string instance_name;
-  bool is_field_decl;
-  clang::Decl *decl;
-  clang::Decl *instance_decl;
-
-  ModuleInstanceType()
-      : var_name{},
-        var_type_name{},
-        instance_name{},
-        is_field_decl{false},
-        decl{nullptr} {}
-
-  ModuleInstanceType(const ModuleInstanceType &rhs) {
-    var_name = rhs.var_name;
-    var_type_name = rhs.var_type_name;
-    instance_name = rhs.instance_name;
-    is_field_decl = rhs.is_field_decl;
-    decl = rhs.decl;
-    instance_decl = rhs.instance_decl;
-  }
-
-  bool operator==(const ModuleInstanceType &rhs) {
-    return std::tie(var_name, var_type_name, instance_name, is_field_decl, decl,
-                    instance_decl) ==
-           std::tie(rhs.var_name, rhs.var_type_name, rhs.instance_name,
-                    rhs.is_field_decl, rhs.decl, rhs.instance_decl);
-  }
-
-  void dump() {
-    llvm::outs() << "type_decl: " << decl << " inst_decl: " << instance_decl
-                 << " var_type_name: " << var_type_name
-                 << " var_name: " << var_name
-                 << " instance_name: " << instance_name
-                 << " is_field_decl: " << is_field_decl << "\n";
-  }
 };
 
 class InstanceArgumentMatcher : public MatchFinder::MatchCallback {

--- a/src/ModuleDecl.h
+++ b/src/ModuleDecl.h
@@ -13,7 +13,8 @@
 #include "Signal.h"
 #include "clang/AST/DeclCXX.h"
 
-#include "InstanceMatcher.h"
+#include "ModuleInstanceType.h"
+//#include "InstanceMatcher.h"
 namespace scpar {
 using namespace clang;
 

--- a/src/ModuleInstanceType.h
+++ b/src/ModuleInstanceType.h
@@ -1,0 +1,53 @@
+#ifndef _MODULE_INSTANCE_TYPE_
+#define _MODULE_INSTANCE_TYPE_
+
+#include <string>
+#include "llvm/Support/raw_ostream.h"
+
+namespace clang { class Decl; }
+
+namespace sc_ast_matchers {
+struct ModuleInstanceType {
+  std::string var_name;
+  std::string var_type_name;
+  std::string instance_name;
+  bool is_field_decl;
+  clang::Decl *decl;
+  clang::Decl *instance_decl;
+
+  ModuleInstanceType()
+      : var_name{},
+        var_type_name{},
+        instance_name{},
+        is_field_decl{false},
+        decl{nullptr} {}
+
+  ModuleInstanceType(const ModuleInstanceType &rhs) {
+    var_name = rhs.var_name;
+    var_type_name = rhs.var_type_name;
+    instance_name = rhs.instance_name;
+    is_field_decl = rhs.is_field_decl;
+    decl = rhs.decl;
+    instance_decl = rhs.instance_decl;
+  }
+
+  bool operator==(const ModuleInstanceType &rhs) {
+    return std::tie(var_name, var_type_name, instance_name, is_field_decl, decl,
+                    instance_decl) ==
+           std::tie(rhs.var_name, rhs.var_type_name, rhs.instance_name,
+                    rhs.is_field_decl, rhs.decl, rhs.instance_decl);
+  }
+
+  void dump() {
+    llvm::outs() << "type_decl: " << decl << " inst_decl: " << instance_decl
+                 << " var_type_name: " << var_type_name
+                 << " var_name: " << var_name
+                 << " instance_name: " << instance_name
+                 << " is_field_decl: " << is_field_decl << "\n";
+  }
+};
+};
+
+
+#endif
+

--- a/src/Signal.h
+++ b/src/Signal.h
@@ -6,12 +6,12 @@
 #include "json.hpp"
 
 #include "FindSignals.h"
-//#include "FindTemplateTypes.h"
 
 namespace scpar {
 using namespace clang;
 using json = nlohmann::json;
 
+// Forward declarations.
 class FindTemplateTypes;
 class SignalContainer;
 

--- a/src/SystemCClang.cpp
+++ b/src/SystemCClang.cpp
@@ -25,7 +25,7 @@ bool SystemCConsumer::fire() {
   // ANI : Do we need FindGlobalEvents?
   FindGlobalEvents globals{tu, os_};
   FindGlobalEvents::globalEventMapType eventMap{globals.getEventMap()};
-  //globals.dump_json();
+  // globals.dump_json();
   systemcModel_->addGlobalEvents(eventMap);
 
   //
@@ -139,15 +139,18 @@ bool SystemCConsumer::fire() {
       //
       os_ << "\n";
       os_ << "1. Set instance name: " << get<0>(instance) << "\n";
-      //add_module_decl->setInstanceName(get<0>(instance));
+      // add_module_decl->setInstanceName(get<0>(instance));
       os_ << "2. Set instance type decl: " << cxx_decl->getNameAsString() << " "
           << get<1>(instance) << "\n";
-      auto inst_info{ get<2>(instance) };
+      auto inst_info{get<2>(instance)};
       inst_info.dump();
-      add_module_decl->setInstanceInfo( get<2>(instance));
-      //add_module_decl->setInstanceDecl(get<1>(instance));
+      add_module_decl->setInstanceInfo(get<2>(instance));
+      // add_module_decl->setInstanceDecl(get<1>(instance));
 
       // 2. Find the template arguments for the class.
+      // In clang lingo: parameters are the templated values, and the arguments
+      // are the specialization values for the templates.
+      //
       os_ << "3. Set template arguments\n";
       FindTemplateParameters tparms{cxx_decl, os_};
       add_module_decl->setTemplateParameters(tparms.getTemplateParameters());
@@ -225,7 +228,7 @@ bool SystemCConsumer::fire() {
 
   // scmain.getSCMainFunctionDecl()->dump();
 
-    netlist_registry.match(*scmain.getSCMainFunctionDecl(), getContext());
+  netlist_registry.match(*scmain.getSCMainFunctionDecl(), getContext());
   // TODO: Fix the top-level
   if (getTopModule() == "!none") {
     llvm::outs() << " No top module\n";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,21 +38,21 @@ file(COPY data DESTINATION ${CMAKE_BINARY_DIR}/tests/ )
 file(COPY ../examples/llnl-examples DESTINATION ${CMAKE_BINARY_DIR}/tests/data )
 
 set( UNIT_TEST_LIST 
-  # t1
-  # t2
-  # t3
-  # t4-matchers
-  # clock-parsing
-  # test-xor-hierarchy
+  t1
+  t2
+  t3
+  t4-matchers
+  clock-parsing
+  test-xor-hierarchy
   hotfix-40-findtemplatetypes
-  # t5-template-matching
-  # portarray-example
-#
-  # Unit tests for structures
-  # tree-test
-  # instance-matcher
-  # netlist-matcher
-  # netlist-templated-matcher
+  t5-template-matching
+  portarray-example
+
+# Unit tests for structures
+  tree-test
+  instance-matcher
+  netlist-matcher
+  netlist-templated-matcher
 #
   )
 
@@ -62,7 +62,7 @@ set(UNIT_MATCHER_TEST_LIST
 
 if (PLUGIN_XLAT)
 set ( UNIT_XLAT_TEST_LIST 
-  # sreg-test
+   sreg-test
   )
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,27 +38,31 @@ file(COPY data DESTINATION ${CMAKE_BINARY_DIR}/tests/ )
 file(COPY ../examples/llnl-examples DESTINATION ${CMAKE_BINARY_DIR}/tests/data )
 
 set( UNIT_TEST_LIST 
-  t1
-  t2
-  t3
-  t4-matchers
-  clock-parsing
-  test-xor-hierarchy
+  # t1
+  # t2
+  # t3
+  # t4-matchers
+  # clock-parsing
+  # test-xor-hierarchy
   hotfix-40-findtemplatetypes
-  t5-template-matching
-  portarray-example
+  # t5-template-matching
+  # portarray-example
+#
+  # Unit tests for structures
+  # tree-test
+  # instance-matcher
+  # netlist-matcher
+  # netlist-templated-matcher
+#
+  )
 
-  # # Unit tests for structures
-  tree-test
-  instance-matcher
-  netlist-matcher
-  netlist-templated-matcher
-
+set(UNIT_MATCHER_TEST_LIST 
+  find-members
   )
 
 if (PLUGIN_XLAT)
 set ( UNIT_XLAT_TEST_LIST 
-  sreg-test
+  # sreg-test
   )
 endif()
 
@@ -69,6 +73,24 @@ include(CTest)
 # so we can use -iquote instead of -I to include files in src folder
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -iquote ${PROJECT_SOURCE_DIR}/src")
+
+# Just unit tests that do not need systemc-clang to run.
+foreach(NAME IN LISTS UNIT_MATCHER_TEST_LIST)
+  list(APPEND UNIT_TEST_SOURCE_LIST
+    ${NAME}.cpp)
+  set(TEST_SOURCE_NAME ${NAME})
+  set(TARGET_NAME ${NAME})
+  add_executable(${TARGET_NAME} main.cpp ${TEST_SOURCE_NAME} )
+    
+  target_link_libraries(${TARGET_NAME} PUBLIC findtemplatetypes ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_SYSTEM_LIBS})
+  
+  target_include_directories(${TARGET_NAME} PUBLIC ../externals/catch2/ PUBLIC ../tests/ PUBLIC ${CMAKE_BINARY_DIR}/tests/ )
+  add_test( NAME ${TARGET_NAME} COMMAND ${TARGET_NAME} 
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/data/ )
+endforeach()
+
+
+# This is to link with SystemC clang
 foreach(NAME IN LISTS UNIT_TEST_LIST)
   list(APPEND UNIT_TEST_SOURCE_LIST
     ${NAME}.cpp)

--- a/tests/find-members.cpp
+++ b/tests/find-members.cpp
@@ -1,0 +1,121 @@
+#include "SystemCClang.h"
+#include "catch.hpp"
+#include "clang/Tooling/Tooling.h"
+
+#include "FindMemberFieldMatcher.h"
+#include "Matchers.h"
+
+// This is automatically generated from cmake.
+#include "ClangArgs.h"
+#include "Testing.h"
+
+using namespace clang::ast_matchers;
+using namespace scpar;
+using namespace sc_ast_matchers;
+
+template <typename T>
+bool find_name(std::vector<T> &names, const T &find_name) {
+  auto found_it = std::find(names.begin(), names.end(), find_name);
+  if (found_it != names.end()) {
+    names.erase(found_it);
+    return true;
+  }
+
+  return false;
+}
+
+// This test works
+TEST_CASE("Read SystemC model from file for testing", "[parsing]") {
+  std::string code{systemc_clang::read_systemc_file(
+      systemc_clang::test_data_dir, "xor-hierarchy.cpp")};
+
+  ASTUnit *from_ast =
+      tooling::buildASTFromCodeWithArgs(code, systemc_clang::catch_test_args)
+          .release();
+
+  llvm::outs() << "================ TESTMATCHER =============== \n";
+  InstanceMatcher inst_matcher{};
+  MatchFinder matchRegistry{};
+  inst_matcher.registerMatchers(matchRegistry);
+  // Run all the matchers
+  matchRegistry.matchAST(from_ast->getASTContext());
+  inst_matcher.dump();
+  llvm::outs() << "================ END =============== \n";
+
+  SECTION("Test instance matcher", "[instance-matcher]") {
+    // There should be five instances here.
+    // DUT2, n1, n2, n3, n4
+    auto instances{inst_matcher.getInstanceMap()};
+
+    REQUIRE(instances.size() == 6);
+
+    std::vector<std::string> var_names{"DUT", "TestClk", "n1",
+                                       "n2",  "n3",      "n4"};
+    std::vector<std::string> var_type_names{
+        "struct exor2", "class sc_core::sc_clock",
+        "struct nand2", "struct nand2",
+        "struct nand2", "struct nand2"};
+    std::vector<std::string> instance_names{"exor2", "TestClock", "N1",
+                                            "N2",    "N3",        "N4"};
+
+    for (auto const &entry : instances) {
+      auto inst{entry.second};
+      inst.dump();
+
+      find_name(var_names, inst.var_name);
+      find_name(var_type_names, inst.var_type_name);
+      find_name(instance_names, inst.instance_name);
+
+      // Test findInstanceByVariableType()
+      if (inst.is_field_decl) {
+        auto fdecl{(cast<FieldDecl>(entry.first))};
+        auto cxx_decl{fdecl->getType().getTypePtr()->getAsCXXRecordDecl()};
+
+        std::vector<InstanceMatcher::InstanceDeclType> found_instances;
+        inst_matcher.findInstanceByVariableType(cxx_decl, found_instances);
+
+        if (inst.var_name == "DUT") {
+          // Find all the instances of exor2
+          llvm::errs() << "<<<< DUT\n";
+          REQUIRE(found_instances.size() == 1);
+        } else {
+          llvm::errs() << "<<<< NOT DUT\n";
+          // Find all the instances of nand2
+          REQUIRE(found_instances.size() == 4);
+        }
+
+        // Run the FieldMemberMatcher on it to get all the FieldDecls in it.
+        sc_ast_matchers::FindMemberFieldMatcher field_matcher{};
+        MatchFinder registry{};
+        field_matcher.registerMatchers(registry);
+
+        // Notice that the match() call must have the context.  We can get it
+        // from the SystemCConsumer object.
+        registry.match(*cxx_decl, from_ast->getASTContext());
+
+        // Check to see if we got the FieldDecl we expect.
+        std::vector<FieldDecl *> fields{field_matcher.getFieldDecls()};
+
+        llvm::outs() << "- number of FieldDecl in type " << fields.size()
+                     << "\n";
+
+        for (auto const &fld : fields) {
+          fld->dump();
+
+          const Type *field_type{fld->getType().getTypePtr()};
+          FindTemplateTypes find_tt{};
+          find_tt.Enumerate(field_type);
+
+          // Ge the tree.
+          auto template_args{find_tt.getTemplateArgTreePtr()};
+          std::string dft_str{template_args->dft()};
+          llvm::outs() << dft_str << "\n";
+        }
+      }
+    }
+    // All the variable name should be found
+    REQUIRE(var_names.size() == 0);
+    REQUIRE(var_type_names.size() == 0);
+    REQUIRE(instance_names.size() == 0);
+  }
+}

--- a/tests/hotfix-40-findtemplatetypes.cpp
+++ b/tests/hotfix-40-findtemplatetypes.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 
+#include "FindMemberFieldMatcher.h"
 #include "SystemCClang.h"
 
 /// This is automatically generated from cmake.
@@ -248,6 +249,38 @@ int sc_main(int argc, char *argv[]) {
         llvm::outs() << "\n@> name: " << name
                      << ", type name: " << type_data->getTypeName() << " ";
 
+        // Get the Type pointer, and then try to get the field members for it.
+        const Type *arg_type_ptr{type_data->getTypePtr()};
+
+        // Check that the Type is of a class or record.
+        if (arg_type_ptr->isClassType() || arg_type_ptr->isRecordType()) {
+          // Get the CXXRecordDecl
+          auto cxx_decl{arg_type_ptr->getAsCXXRecordDecl()};
+
+          // Run the FieldMemberMatcher on it to get all the FieldDecls in it.
+          sc_ast_matchers::FindMemberFieldMatcher field_matcher{};
+          MatchFinder registry{};
+          field_matcher.registerMatchers(registry);
+
+          // Notice that the match() call must have the context.  We can get it
+          // from the SystemCConsumer object.
+          registry.match(*cxx_decl, sc.getContext());
+
+          // Check to see if we got the FieldDecl we expect.
+          std::vector<FieldDecl *> fields{field_matcher.getFieldDecls()};
+
+          llvm::outs() << "- number of FieldDecl in type "
+                       << type_data->getTypeName() << " " << fields.size()
+                       << "\n";
+
+          for (auto const &fld : fields) {
+            if (type_data->getTypeName() == "fp_t") {
+              REQUIRE((fld->getName() == "frac" || fld->getName() == "expo" ||
+                       fld->getName() == "sign"));
+            }
+          }
+        }
+
         // Access the parent of the current node.
         // If the node is a pointer to itself, then the node itself is the
         // parent. Otherwise, it points to the parent node.
@@ -306,6 +339,38 @@ int sc_main(int argc, char *argv[]) {
         auto type_data{node->getDataPtr()};
         llvm::outs() << "\n@> name: " << name
                      << ", type name: " << type_data->getTypeName() << " ";
+
+        // Get the Type pointer, and then try to get the field members for it.
+        const Type *arg_type_ptr{type_data->getTypePtr()};
+
+        // Check that the Type is of a class or record.
+        if (arg_type_ptr->isClassType() || arg_type_ptr->isRecordType()) {
+          // Get the CXXRecordDecl
+          auto cxx_decl{arg_type_ptr->getAsCXXRecordDecl()};
+
+          // Run the FieldMemberMatcher on it to get all the FieldDecls in it.
+          sc_ast_matchers::FindMemberFieldMatcher field_matcher{};
+          MatchFinder registry{};
+          field_matcher.registerMatchers(registry);
+
+          // Notice that the match() call must have the context.  We can get it
+          // from the SystemCConsumer object.
+          registry.match(*cxx_decl, sc.getContext());
+
+          // Check to see if we got the FieldDecl we expect.
+          std::vector<FieldDecl *> fields{field_matcher.getFieldDecls()};
+
+          llvm::outs() << "- number of FieldDecl in type "
+                       << type_data->getTypeName() << " " << fields.size()
+                       << "\n";
+
+          for (auto const &fld : fields) {
+            if (type_data->getTypeName() == "MyType") {
+              REQUIRE((fld->getName() == "info" || fld->getName() == "flag"));
+            }
+            fld->dump();
+          }
+        }
 
         // Access the parent of the current node.
         // If the node is a pointer to itself, then the node itself is the

--- a/tests/hotfix-40-findtemplatetypes.cpp
+++ b/tests/hotfix-40-findtemplatetypes.cpp
@@ -365,10 +365,20 @@ int sc_main(int argc, char *argv[]) {
                        << "\n";
 
           for (auto const &fld : fields) {
+            fld->dump();
             if (type_data->getTypeName() == "MyType") {
               REQUIRE((fld->getName() == "info" || fld->getName() == "flag"));
             }
-            fld->dump();
+            // Try to get the template type of these fields.
+            const Type *field_type{fld->getType().getTypePtr()};
+            FindTemplateTypes find_tt{};
+            find_tt.Enumerate(field_type);
+
+            // Ge the tree.
+            auto template_args{find_tt.getTemplateArgTreePtr()};
+            // Access the tree here in the way on wishes.
+            std::string dft_str{template_args->dft()};
+            llvm::outs() << "DFT: " << dft_str << "\n";
           }
         }
 

--- a/tests/t1.cpp
+++ b/tests/t1.cpp
@@ -1,7 +1,6 @@
 #include "catch.hpp"
 
 #include "SystemCClang.h"
-
 // This is automatically generated from cmake.
 #include <iostream>
 #include "ClangArgs.h"
@@ -95,10 +94,10 @@ int sc_main(int argc, char *argv[]) {
       tooling::buildASTFromCodeWithArgs(code, systemc_clang::catch_test_args)
           .release();
 
-  SystemCConsumer sc{from_ast};
-  sc.HandleTranslationUnit(from_ast->getASTContext());
+  SystemCConsumer systemc_clang_consumer{from_ast};
+  systemc_clang_consumer.HandleTranslationUnit(from_ast->getASTContext());
 
-  auto model{sc.getSystemCModel()};
+  auto model{systemc_clang_consumer.getSystemCModel()};
 
   // This provides the module declarations.
   auto module_decl{model->getModuleDecl()};
@@ -155,10 +154,11 @@ int sc_main(int argc, char *argv[]) {
 
       // Note: template_args must be dereferenced.
       for (auto const &node : *template_args) {
-        auto type_data{node->getDataPtr()};
-        llvm::outs() << "\n@> name: " << name
+        const TemplateType *type_data{node->getDataPtr()};
+        llvm::outs() << "\n- name: " << name
                      << ", type name: " << type_data->getTypeName() << " ";
 
+    
         // Access the parent of the current node.
         // If the node is a pointer to itself, then the node itself is the
         // parent. Otherwise, it points to the parent node.


### PR DESCRIPTION
Provide example code to use `FindTemplateTypes` and find the `FieldDecl`s within a recognized type.

A better classification of the files under `src/` should be done to improve the compilation of tests.