### PR TITLE
Replace Signal to SignalDecl

### DIFF
--- a/plugins/xlat/Xlat.cpp
+++ b/plugins/xlat/Xlat.cpp
@@ -116,7 +116,7 @@ void Xlat::xlatsig(ModuleDecl::signalMapType pmap, hNode::hdlopsEnum h_op,
 
     os_ << "object name is " << objname << "\n";
 
-    Signal *pd = get<1>(*mit);
+    SignalDecl *pd = get<1>(*mit);
 
     Tree<TemplateType> *template_argtp = (pd->getTemplateTypes())->getTemplateArgTreePtr();
     xlattype(objname, template_argtp, h_op, h_info);  // passing the sigvarlist


### PR DESCRIPTION
Removed `SignalContainer`.  Replaced `Signal` with `SignalDecl`, which inherits from `PortDecl`.  This fix makes one minor change to `Xlat.cpp` to make it compile.  