### PR TITLE
Add an option to specify the path for the generated HDL file.

### DIFF
--- a/plugins/hdl/HDLMain.cpp
+++ b/plugins/hdl/HDLMain.cpp
@@ -41,6 +41,11 @@ bool HDLMain::postFire() {
   std::error_code ec;
   string outputfn;
 
+  /// File namd passed from command line argument.
+  //
+
+  LLVM_DEBUG(llvm::dbgs() << "HDL-FILE-OUTPUT: " << hdl_file_out_ << "\n"; );
+
   FileID fileID = getSourceManager().getMainFileID();
   const FileEntry *fileentry = getSourceManager().getFileEntryForID(fileID);
   if (!fileentry) {

--- a/plugins/hdl/HDLMain.h
+++ b/plugins/hdl/HDLMain.h
@@ -18,75 +18,90 @@ using namespace clang;
 using namespace systemc_clang;
 using namespace hnode;
 using namespace llvm;
-//static llvm::cl::OptionCategory HDLcategory("systemc-clang options");
+// static llvm::cl::OptionCategory HDLcategory("systemc-clang options");
 
-
-class HDLMain: public SystemCConsumer {
-
-  public:
-  HDLMain( CompilerInstance& ci, std::string topModule = "!none" )
-    : SystemCConsumer( ci, topModule ) {
-    }
-  HDLMain( ASTUnit *from_ast, std::string topModule = "!none" )
-    : SystemCConsumer(from_ast,topModule) {
-  }
+class HDLMain : public SystemCConsumer {
+ public:
+  /// Provide hdl_file_out as argument
+  HDLMain(CompilerInstance &ci, std::string topModule = "!none",
+          const std::string &hdl_file_out = "default_hdl.txt")
+      : SystemCConsumer(ci, topModule), hdl_file_out_{hdl_file_out} {}
+  HDLMain(ASTUnit *from_ast, std::string topModule = "!none",
+          const std::string &hdl_file_out = "default_hdl.txt")
+      : SystemCConsumer(from_ast, topModule), hdl_file_out_{hdl_file_out} {}
 
   bool postFire();
-  void SCmodule2hcode(ModuleInstance *mod, hNodep &h_module, llvm::raw_fd_ostream &SCout );
-  void SCport2hcode(ModuleInstance::portMapType pmap, hNode::hdlopsEnum h_op, hNodep &h_info);
-  void SCsig2hcode(ModuleInstance::signalMapType pmap, hNode::hdlopsEnum h_op, hNodep &h_info);
-  void SCproc2hcode(ModuleInstance::processMapType pm, hNodep & h_top);
-  void SCportbindings2hcode(systemc_clang::ModuleInstance::portBindingMapType portbindingmap, hNodep &h_pb);
-  private:
+  void SCmodule2hcode(ModuleInstance *mod, hNodep &h_module,
+                      llvm::raw_fd_ostream &SCout);
+  void SCport2hcode(ModuleInstance::portMapType pmap, hNode::hdlopsEnum h_op,
+                    hNodep &h_info);
+  void SCsig2hcode(ModuleInstance::signalMapType pmap, hNode::hdlopsEnum h_op,
+                   hNodep &h_info);
+  void SCproc2hcode(ModuleInstance::processMapType pm, hNodep &h_top);
+  void SCportbindings2hcode(
+      systemc_clang::ModuleInstance::portBindingMapType portbindingmap,
+      hNodep &h_pb);
 
-    hNodep h_top;
-    std::unordered_map<string, FunctionDecl *> allmethodecls;  //  all methods/functions called
-    
-    HDLType HDLt;
+ private:
+  hNodep h_top;
+  std::unordered_map<string, FunctionDecl *>
+      allmethodecls;  //  all methods/functions called
 
-    hname_map_t mod_name_map;
-    name_serve mod_newn{"_sc_module_"};
+  HDLType HDLt;
+
+  hname_map_t mod_name_map;
+  name_serve mod_newn{"_sc_module_"};
+
+  /// Command line options
+  std::string hdl_file_out_;
 };
 
-
 // static llvm::cl::opt<std::string> HDLtop(
-    // "top",
-    // llvm::cl::desc("Specify top-level module declaration for entry point"),
-    // llvm::cl::cat(HDLcategory));
+// "top",
+// llvm::cl::desc("Specify top-level module declaration for entry point"),
+// llvm::cl::cat(HDLcategory));
 //
 //
 
 class HDLAXN : public ASTFrontendAction {
  public:
   HDLAXN(const std::string &top) : top_{top} {};
+  HDLAXN(const std::string &top, const std::string &hdl_file_out)
+      : top_{top}, hdl_file_out_{hdl_file_out} {};
 
  private:
   std::string top_;
+  std::string hdl_file_out_;
 
  public:
   virtual std::unique_ptr<ASTConsumer> CreateASTConsumer(
       clang::CompilerInstance &Compiler, llvm::StringRef inFile) {
-    return std::unique_ptr<ASTConsumer>(new HDLMain(Compiler, top_));
+    return std::unique_ptr<ASTConsumer>(new HDLMain(Compiler, top_, hdl_file_out_));
   }
 };
 
 ////
-class HDLFrontendActionFactory: public clang::tooling::FrontendActionFactory {
-public:
-    HDLFrontendActionFactory(const std::string &top) : top_module_declaration_{top} {
+class HDLFrontendActionFactory : public clang::tooling::FrontendActionFactory {
+ public:
+  HDLFrontendActionFactory(const std::string &top)
+      : top_module_declaration_{top}, hdl_file_out_{"default_hdl.txt"} {}
 
-    }
+  HDLFrontendActionFactory(const std::string &top,
+                           const std::string &hdl_file_out)
+      : top_module_declaration_{top}, hdl_file_out_{hdl_file_out} {}
 
-    std::unique_ptr<clang::FrontendAction> create() override {
-      return std::unique_ptr<FrontendAction>(new HDLAXN(top_module_declaration_));
-    }
+  std::unique_ptr<clang::FrontendAction> create() override {
+    return std::unique_ptr<FrontendAction>(
+        new HDLAXN{top_module_declaration_, hdl_file_out_});
+  }
 
-protected:
-    std::string top_module_declaration_;
+ protected:
+  std::string top_module_declaration_;
+  std::string hdl_file_out_;
 };
 
-//std::unique_ptr<clang::tooling::FrontendActionFactory> newFrontendActionFactory(const std::string &top_module);
-
+// std::unique_ptr<clang::tooling::FrontendActionFactory>
+// newFrontendActionFactory(const std::string &top_module);
 
 ///
 class HDLPluginAction {
@@ -96,47 +111,57 @@ class HDLPluginAction {
     //
     //
     //
-llvm::cl::OptionCategory HDLcategory("HDL options");
-llvm::cl::opt<std::string> topModule(
-    "top-module",
-    llvm::cl::desc("Specify top-level module declaration for synthesis entry point"),
-    llvm::cl::cat(HDLcategory));
+    llvm::cl::OptionCategory HDLcategory("HDL options");
+    llvm::cl::opt<std::string> topModule(
+        "top-module",
+        llvm::cl::desc(
+            "Specify top-level module declaration for synthesis entry point"),
+        llvm::cl::cat(HDLcategory));
 
-llvm::cl::opt<bool> debug_mode(
-    "debug",
-    llvm::cl::desc("Enable debug output from systemc-clang"),
-    llvm::cl::cat(HDLcategory));
+    llvm::cl::opt<bool> debug_mode(
+        "debug", llvm::cl::desc("Enable debug output from systemc-clang"),
+        llvm::cl::cat(HDLcategory));
 
-llvm::cl::opt<std::string> debug_only(
-    "debug-only",
-    llvm::cl::desc("Enable debug only for the specified DEBUG_TYPE"),
-    llvm::cl::cat(HDLcategory));
+    llvm::cl::opt<std::string> debug_only(
+        "debug-only",
+        llvm::cl::desc("Enable debug only for the specified DEBUG_TYPE"),
+        llvm::cl::cat(HDLcategory));
+
+    llvm::cl::opt<std::string> hdl_file_out(
+        "hdl-file-out", llvm::cl::desc("HDL output file location"),
+        llvm::cl::cat(HDLcategory));
 
     CommonOptionsParser OptionsParser(argc, argv, HDLcategory);
+
     ClangTool Tool(OptionsParser.getCompilations(),
                    OptionsParser.getSourcePathList());
 
     /// Setup the debug mode.
     //
-    if (debug_mode || (debug_only != "") ) {
+    if (debug_mode || (debug_only != "")) {
       LLVM_DEBUG(llvm::dbgs() << "Debug mode enabled\n";);
       llvm::DebugFlag = true;
     }
 
     if (debug_only != "") {
-#ifdef  __clang__
+#ifdef __clang__
       setCurrentDebugType(debug_only.c_str());
 #else
       llvm::setCurrentDebugType(debug_only.c_str());
 #endif
     }
 
+    if (hdl_file_out != "") {
+      LLVM_DEBUG(llvm::dbgs()
+                     << "HDL output file specified: " << hdl_file_out << "\n";);
+    }
 
     std::unique_ptr<FrontendActionFactory> FrontendFactory;
-//    FrontendFactory = newFrontendActionFactory<HDLAXN>();
-    //FrontendFactory = newFrontendActionFactory(h);
-    
-   FrontendFactory = std::unique_ptr<tooling::FrontendActionFactory>(new HDLFrontendActionFactory(topModule));
+    //    FrontendFactory = newFrontendActionFactory<HDLAXN>();
+    // FrontendFactory = newFrontendActionFactory(h);
+
+    FrontendFactory = std::unique_ptr<tooling::FrontendActionFactory>(
+        new HDLFrontendActionFactory{topModule, hdl_file_out});
     Tool.run(FrontendFactory.get());
   };
 };


### PR DESCRIPTION
Added an option hdl-file-out where one can specify the path for the
generated HDL file. Internally, the plugin can use hdl_file_out_ in
HDLMain class to access it.