### PR TITLE
Add targets for documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,9 @@ target_include_directories(Catch INTERFACE ${CATCH_INCLUDE_DIR})
 include(CTest)
 include(Catch)
 
+option(BUILD_DOC "Set this option to build with documentation targets" OFF)
+
+if (BUILD_DOC)
 ##################################################
 # Sphinx
 ##################################################
@@ -110,6 +113,8 @@ add_custom_target(docs
     COMMENT "Generating Doxygen and Sphinx documentation"
     VERBATIM )
 endif()
+
+endif (BUILD_DOC)
 ##################################################
 # Required packages
 # Include the these flags whenever you compile.
@@ -423,8 +428,11 @@ message(STATUS "Python found          : ${PYTHONINTERP_FOUND}")
 message(STATUS "Python interpreter    : ${PYTHON_EXECUTABLE}")
 message(STATUS "")
 message(STATUS "[ Docymentation ]")
+message(STATUS "Build documentation   : ${BUILD_DOC}")
+if (BUILD_DOC)
 message(STATUS "Doxygen found         : ${DOXYGEN_FOUND}")
 message(STATUS "Sphinx found          : ${SPHINX_FOUND}")
+endif (BUILD_DOC)
 message(STATUS "")
 message(STATUS "[ Git info.     ]")
 message(STATUS "Git repo url          : ${GIT_REPO_URL}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,28 +61,25 @@ include(Catch)
 ##################################################
 # Sphinx
 ##################################################
-# include(FindSphinx)
-#
-# set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/docs/source/)
-# set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/docs/)
-#
-# add_custom_target(sphinx ALL
-                  # COMMAND
-                  # ${SPHINX_EXECUTABLE} -M html
-                  # ${SPHINX_SOURCE} ${SPHINX_BUILD}
-                  # WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                  # COMMENT "Generating documentation with Sphinx")
-#
+include(FindSphinx)
+
+set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/docs/source/)
+set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/docs/)
+
+add_custom_target(sphinx
+                  COMMAND
+                  ${SPHINX_EXECUTABLE} -M html
+                  ${SPHINX_SOURCE} ${SPHINX_BUILD}
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                  COMMENT "Generating documentation with Sphinx")
 
 
 ##################################################
 # Doxygen
 ##################################################
 # look for Doxygen package
-option(BUILD_DOC "Build documentation" OFF)
 find_package(Doxygen)
 
-if (BUILD_DOC)
 if (DOXYGEN_FOUND)
     # set input and output files
     set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/source//Doxyfile.in)
@@ -90,7 +87,6 @@ if (DOXYGEN_FOUND)
 
     # request to configure the file
     configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
-    message("Doxygen build started")
 
     # Note: do not put "ALL" - this builds docs together with application EVERY TIME!
     add_custom_target( doxygen
@@ -103,7 +99,17 @@ else (DOXYGEN_FOUND)
   message(FATAL_ERROR "FATAL: DOXYGEN not found.")
 
 endif (DOXYGEN_FOUND)
-endif (BUILD_DOC)
+
+if (DOXYGEN_FOUND AND SPHINX_EXECUTABLE)
+add_custom_target(docs  
+    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
+    COMMAND
+              ${SPHINX_EXECUTABLE} -M html
+              ${SPHINX_SOURCE} ${SPHINX_BUILD}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Generating Doxygen and Sphinx documentation"
+    VERBATIM )
+endif()
 ##################################################
 # Required packages
 # Include the these flags whenever you compile.
@@ -417,7 +423,6 @@ message(STATUS "Python found          : ${PYTHONINTERP_FOUND}")
 message(STATUS "Python interpreter    : ${PYTHON_EXECUTABLE}")
 message(STATUS "")
 message(STATUS "[ Docymentation ]")
-message(STATUS "Build docs            : ${BUILD_DOC}")
 message(STATUS "Doxygen found         : ${DOXYGEN_FOUND}")
 message(STATUS "Sphinx found          : ${SPHINX_FOUND}")
 message(STATUS "")

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,9 @@ Documentation
 --------------
 
 * `https://systemc-clang.readthedocs.io <https://systemc-clang.readthedocs.io>`_
+* It is possible to build the documentation by specifying the ``-DBUILD_DOC=ON`` flag. This will provide the following targets
+  ** ``doxygen``: Builds Doxygen documentation.
+  ** ``sphinx`` : Builds Sphinx documentation.
 
 Tests
 -------

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -1,0 +1,17 @@
+find_program(SPHINX_EXECUTABLE
+             NAMES sphinx-build sphinx-build2
+             DOC "Path to sphinx-build executable")
+
+# Handle REQUIRED and QUIET arguments
+# this will also set SPHINX_FOUND to true if SPHINX_EXECUTABLE exists
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Sphinx
+                                  "Failed to locate sphinx-build executable"
+                                  SPHINX_EXECUTABLE)
+
+# Provide options for controlling different types of output
+option(SPHINX_OUTPUT_HTML "Output standalone HTML files" ON)
+option(SPHINX_OUTPUT_MAN "Output man pages" ON)
+
+option(SPHINX_WARNINGS_AS_ERRORS "When building documentation treat warnings as errors" ON)
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ extensions = ['recommonmark'
         , 'sphinx.ext.autosectionlabel'
         # , 'sphinx.ext.'
         , 'breathe'
-        #, 'exhale'
+        , 'exhale'
         ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ extensions = ['recommonmark'
         , 'sphinx.ext.autosectionlabel'
         # , 'sphinx.ext.'
         , 'breathe'
-        , 'exhale'
+        #, 'exhale'
         ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,7 @@ extensions = ['recommonmark'
         , 'sphinx.ext.intersphinx'
         , 'sphinx.ext.autosectionlabel'
         # , 'sphinx.ext.'
-        #, 'breathe'
+        , 'breathe'
         #, 'exhale'
         ]
 
@@ -78,11 +78,11 @@ html_theme = 'sphinx_rtd_theme' #'alabaster'
 # -- Breath and Exhale 
 
 
-#breathe_default_project = "systemc-clang"
-#
-#breathe_projects = {
-#    "systemc-clang": "./doxydoc/xml"
-#}
+breathe_default_project = "systemc-clang"
+
+breathe_projects = {
+    "systemc-clang": "./doxydoc/xml"
+}
 
 exhale_args = {
     "containmentFolder":     "./api",


### PR DESCRIPTION
The build infrastructure is adding `BUILD_DOC` option that will generate specific targets for doxygen, sphinx and all documentation. In addition, start using `option` instead of specific variables for options.