### PR TITLE
Nested loops with a break to the outer loop

### DIFF
--- a/src/cfg/SplitCFG.cpp
+++ b/src/cfg/SplitCFG.cpp
@@ -96,7 +96,7 @@ void SplitCFG::dfs_visit_wait(
         // llvm::dbgs() << "\n==============================================";
         llvm::dbgs() << "\n#### BB " << ParentBB->getBlockID()
                      << " is a loop with 2 succ\n";
-        llvm::SmallPtrSet<const SplitCFGBlock*, 32> loop_visited_blocks;
+        llvm::SmallPtrSet<const SplitCFGBlock*, 32> loop_visited_blocks{visited_blocks};
         // ParentBB has been visited so don't revisit it
         loop_visited_blocks.insert(ParentBB);
         dumpVisitedBlocks(loop_visited_blocks);

--- a/src/cfg/SplitCFG.cpp
+++ b/src/cfg/SplitCFG.cpp
@@ -28,7 +28,7 @@ using namespace systemc_clang;
 ///
 void SplitCFG::dfs_visit_wait(
     const SplitCFGBlock* BB,
-    llvm::SmallPtrSetImpl<const SplitCFGBlock*>& visited_blocks,
+    llvm::SmallPtrSet<const SplitCFGBlock*, 32>& visited_blocks,
     llvm::SmallVectorImpl<const SplitCFGBlock*>& waits_to_visit,
     llvm::SmallPtrSetImpl<const SplitCFGBlock*>& visited_waits,
     llvm::SmallVector<std::pair<const SplitCFGBlock*, SplitCFGPathInfo>>&
@@ -85,12 +85,13 @@ void SplitCFG::dfs_visit_wait(
     //
     // If there is a successor that has not been visited, then remember that
     // block.
+    dumpVisitedBlocks(visited_blocks);
     bool found_succ{getUnvisitedSuccessor(ParentBB, I, visited_blocks, BB)};
-    // llvm::dbgs() << "Found successor BB " << BB->getBlockID()
-    //             << " for parentBB " << ParentBB->getBlockID() << "\n";
+    llvm::dbgs() << "Found successor BB " << BB->getBlockID()
+                << " for parentBB " << ParentBB->getBlockID() << "\n";
 
     // FIXME: Should this have found_succ &&?
-    if (isLoopWithTwoSuccessors(ParentBB)) {
+    if (isLoopWithTwoSuccessors(ParentBB) && found_succ) {
       do {
         // llvm::dbgs() << "\n==============================================";
         llvm::dbgs() << "\n#### BB " << ParentBB->getBlockID()
@@ -98,24 +99,24 @@ void SplitCFG::dfs_visit_wait(
         llvm::SmallPtrSet<const SplitCFGBlock*, 32> loop_visited_blocks;
         // ParentBB has been visited so don't revisit it
         loop_visited_blocks.insert(ParentBB);
-        // dumpVisitedBlocks(visited_blocks);
+        dumpVisitedBlocks(loop_visited_blocks);
         visited_blocks.insert(BB);
-        // llvm::dbgs() << "\n==============================================";
-        // llvm::dbgs() << "\nRecurse DFS starting at BB " << BB->getBlockID()
-        //              << " visited_block size " << visited_blocks.size() <<
-        //              "\n";
+        llvm::dbgs() << "\n==============================================";
+        llvm::dbgs() << "\nRecurse DFS starting at BB " << BB->getBlockID()
+                     << " visited_block size " << visited_blocks.size() <<
+                     "\n";
         dfs_visit_wait(BB, loop_visited_blocks, waits_to_visit, visited_waits,
                        curr_path);
         llvm::dbgs() << "\n";
 
         /// This only updates the visited blocks for the subgraph within the
         /// loop. We do not want to update the global visited_blocks yet.
-        updateVisitedBlocks(loop_visited_blocks, loop_visited_blocks);
+        //updateVisitedBlocks(loop_visited_blocks, loop_visited_blocks);
         // dumpVisitedBlocks(visited_blocks);
-        // llvm::dbgs() << "\nEND Recurse DFS"
-        //              << " visited_block size " << visited_blocks.size() <<
-        //              "\n";
-        // llvm::dbgs() << "\n==============================================";
+        llvm::dbgs() << "\nEND Recurse DFS"
+                     << " visited_block size " << visited_blocks.size() <<
+                     "\n";
+        llvm::dbgs() << "\n==============================================";
 
         /// There are two parts to updating the visited blocks.
         /// 1. You do not update the visited blocks when iterating over a
@@ -143,7 +144,7 @@ void SplitCFG::dfs_visit_wait(
       // Only insert successor if recursive call does not visit subgraph.
     }
     addSuccessorToVisitOrPop(bb_has_wait, BB, to_visit, found_succ);
-    // std::cin.get();
+    //std::cin.get();
     // llvm::dbgs() << "to_visit ";
     // dumpSmallVector(to_visit);
     //    llvm::dbgs() << " End loop \n";
@@ -263,7 +264,7 @@ void SplitCFG::dfs_rework() {
 
   const clang::CFGBlock* block{&cfg_->getEntry()};
   const SplitCFGBlock* entry{sccfg_[block->getBlockID()]};
-  llvm::SmallPtrSet<const SplitCFGBlock*, 8> visited_blocks;
+  llvm::SmallPtrSet<const SplitCFGBlock*, 32> visited_blocks;
 
   /// Record the current path.
   llvm::SmallVector<std::pair<const SplitCFGBlock*, SplitCFGPathInfo>>
@@ -282,7 +283,7 @@ void SplitCFG::dfs_rework() {
 
   while (!waits_to_visit.empty()) {
     curr_path.clear();
-    llvm::SmallPtrSet<const SplitCFGBlock*, 8> visited_blocks;
+    visited_blocks.clear();//llvm::SmallPtrSet<const SplitCFGBlock*, 32> visited_blocks;
     entry = waits_to_visit.pop_back_val();
 
     llvm::dbgs() << "\n@@@@@ DFS call for SB " << entry->getBlockID() << "\n";

--- a/src/cfg/SplitCFG.h
+++ b/src/cfg/SplitCFG.h
@@ -159,7 +159,7 @@ class SplitCFG {
  
   void dfs_visit_wait(
       const SplitCFGBlock *BB,
-      llvm::SmallPtrSetImpl<const SplitCFGBlock *> &visited_blocks,
+      llvm::SmallPtrSet<const SplitCFGBlock *, 32> &visited_blocks,
       llvm::SmallVectorImpl<const SplitCFGBlock *> &waits_to_visit,
       llvm::SmallPtrSetImpl<const SplitCFGBlock *> &visited_waits,
       llvm::SmallVector<std::pair<const SplitCFGBlock *, SplitCFGPathInfo>>

--- a/tests/cfg/CMakeLists.txt
+++ b/tests/cfg/CMakeLists.txt
@@ -6,6 +6,7 @@ set (TEST_LIST
   cfg-for-if-wait.cpp
   thread-for-break0.cpp
   thread-for-break1.cpp
+  thread-for-break-nested2.cpp
   cfg-for-stmt-wait.cpp
   cfg-for-break-wait.cpp
 

--- a/tests/cfg/thread-for-break-nested2.cpp
+++ b/tests/cfg/thread-for-break-nested2.cpp
@@ -33,7 +33,7 @@ TEST_CASE("Simple thread test", "[threads]") {
 
   if (data_file.empty()) {
     code = systemc_clang::read_systemc_file(systemc_clang::test_data_dir,
-                                            "simple-thread-input.cpp");
+                                            "thread-for-break-nested2-input.cpp");
   } else {
     code = systemc_clang::read_systemc_file(systemc_clang::test_data_dir,
                                             data_file);
@@ -100,32 +100,25 @@ TEST_CASE("Simple thread test", "[threads]") {
                    << " ***********************\n";
       SplitCFG scfg{from_ast->getASTContext()};
       scfg.construct_sccfg(method);
-      // scfg.dfs_rework();
-      scfg.dumpToDot();
       scfg.generate_paths();
-      scfg.dump();
       llvm::dbgs() << " ===================================================\n";
 
-      /*
       /// Check if all paths are correct.
+      /// These have been worked out by hand.
       unsigned int i{0};
       for (const auto &p : scfg.getPathsFound()) {
         /// There should be 4 paths
         std::string pstr{pathToString(p)};
         if (i == 0) {
-          REQUIRE(pstr == "11 10 9 8 81");
+          REQUIRE(pstr == "17 16 15 14 13 12 11 10 9 8 4 3 7 6 4 3 5 2 21");
         }
         if (i == 1) {
-          REQUIRE(pstr == "82 7 6 5 4 2 1 9 8 81");
-        }
-        if ((i == 2) || (i == 3)) {
-          REQUIRE(pstr == "3 7 6 5 4 2 1 9 8 81");
+          REQUIRE(pstr == "22 1 15 14 13 12 11 10 9 8 4 3 7 6 4 3 5 2 21");
         }
         ++i;
       }
       /// 4 Paths
-      REQUIRE(i == 4);
-      */
+      REQUIRE(i == 2);
     }
 
     llvm::outs() << "data_file: " << data_file << "\n";

--- a/tests/data/thread-for-break-nested2-input.cpp
+++ b/tests/data/thread-for-break-nested2-input.cpp
@@ -1,0 +1,64 @@
+#include "systemc.h"
+
+SC_MODULE(test) {
+  // input ports
+  sc_in_clk clk;
+  sc_in<int> in1;
+  // output ports
+  sc_out<int> out1;
+
+  // others
+  int x;
+  int k;
+
+ void break0() {
+    k = 0;
+    while (true) {
+      k = 1;
+      for (int i = 0; i < 2; i++) {
+        if (i == 1) {
+          k = 2;
+          for (int j = 0; j < 3; j++) {
+            if (j == 1) {
+              k = 4;
+              break;
+            } else {
+              k = 6;
+            }
+          }
+        //  break;
+        }
+        else k = 5;
+          k++;
+      }
+      k = 3;
+      wait();
+      k = 4;
+    }
+  }
+
+  SC_CTOR(test) {
+    int x{2};
+    SC_THREAD(break0);
+    sensitive << clk.pos();
+  }
+};
+
+SC_MODULE(DUT) {
+  sc_signal<int> sig1;
+  sc_signal<double> double_sig;
+
+  test test_instance;
+
+  int others;
+  SC_CTOR(DUT) : test_instance("testing") {
+    test_instance.in1(sig1);
+    test_instance.out1(sig1);
+  }
+};
+
+int sc_main(int argc, char *argv[]) {
+  DUT d("d");
+  return 0;
+}
+


### PR DESCRIPTION
Fixing a bug where a break within a nested loop exits to an outer loop.  The issue was that when the DFS is called, the visited blocks must include the ones from a previous recursive call.